### PR TITLE
Add markdown libs research report

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -5,3 +5,4 @@
 - `03.requirements.md` : 要件定義（機能/データ/非機能/規約）
 - `04.e2e-cases.md` : E2Eテスト仕様（厳密版）
 - `TASKS.md` : 進捗/残タスク管理
+- `markdown-libs/` : Markdown ライブラリ調査レポート（react-markdown / remark-gfm / rehype-sanitize）

--- a/docs/markdown-libs/01.react-markdown.md
+++ b/docs/markdown-libs/01.react-markdown.md
@@ -1,0 +1,192 @@
+# react-markdown
+
+Markdown 文字列を安全に React 要素へ変換するコンポーネントライブラリ。
+unified / remark / rehype エコシステム上に構築されており、`dangerouslySetInnerHTML` を一切使用しない。
+
+## 基本情報
+
+| 項目 | 値 |
+| --- | --- |
+| npm | `react-markdown` |
+| 本プロジェクトのバージョン | ^10.1.0 |
+| ライセンス | MIT |
+| モジュール形式 | ESM のみ（CommonJS 非対応） |
+| リポジトリ | https://github.com/remarkjs/react-markdown |
+
+---
+
+## 1. 概要と特徴
+
+- Markdown をパースし、仮想 DOM（React 要素）を直接構築する
+- `dangerouslySetInnerHTML` を使わないためデフォルトで安全
+- CommonMark 100% 準拠、remark-gfm プラグインで GFM 100% 対応
+- `components` prop でタグごとのレンダリングをカスタマイズ可能
+- `remarkPlugins` / `rehypePlugins` でパイプラインを拡張可能
+
+---
+
+## 2. レンダリングパイプライン
+
+```
+Markdown文字列
+  → [remark-parse] → mdast（Markdown 抽象構文木）
+  → [remarkPlugins による変換]（例: remark-gfm）
+  → [remark-rehype] → hast（HTML 抽象構文木）
+  → [rehypePlugins による変換]（例: rehype-sanitize）
+  → [components マッピング] → React 要素
+```
+
+1. **パース**: Markdown を mdast にパース
+2. **remark 変換**: remarkPlugins で mdast を変換（GFM テーブル・取り消し線等）
+3. **ブリッジ**: remark-rehype で mdast → hast に変換
+4. **rehype 変換**: rehypePlugins で hast を変換（サニタイズ等）
+5. **React 化**: hast ノードを React 要素に変換。`components` で指定したカスタムコンポーネントを適用
+
+---
+
+## 3. エクスポート一覧
+
+| エクスポート | 説明 |
+| --- | --- |
+| `Markdown`（デフォルト） | 同期的に Markdown をレンダリング |
+| `MarkdownAsync` | 非同期プラグイン対応（サーバーサイド向け） |
+| `MarkdownHooks` | クライアントサイドで useEffect/useState を使った非同期対応 |
+| `defaultUrlTransform(url)` | URL 安全化関数（http, https, mailto 等のみ許可） |
+
+---
+
+## 4. Props（設定プロパティ）
+
+| プロパティ | 型 | デフォルト | 説明 |
+| --- | --- | --- | --- |
+| `children` | `string` | — | レンダリングする Markdown 文字列 |
+| `remarkPlugins` | `Array<Plugin>` | `[]` | remark プラグインの配列 |
+| `rehypePlugins` | `Array<Plugin>` | `[]` | rehype プラグインの配列 |
+| `remarkRehypeOptions` | `Options` | — | remark-rehype ブリッジに渡すオプション |
+| `components` | `Components` | — | HTML タグ → カスタム React コンポーネントのマッピング |
+| `allowedElements` | `Array<string>` | 全タグ | 許可タグのホワイトリスト |
+| `disallowedElements` | `Array<string>` | `[]` | 禁止タグのブラックリスト |
+| `allowElement` | `AllowElement` | — | 要素の許可/拒否を判定するカスタム関数 |
+| `unwrapDisallowed` | `boolean` | `false` | 禁止要素を削除せず子要素を展開 |
+| `skipHtml` | `boolean` | `false` | Markdown 内の HTML を完全に無視 |
+| `urlTransform` | `UrlTransform` | `defaultUrlTransform` | URL 変換カスタム関数 |
+
+> `allowedElements` と `disallowedElements` は排他的。同時に指定できない。
+
+---
+
+## 5. 使用例
+
+### 基本
+
+```tsx
+import Markdown from 'react-markdown';
+
+<Markdown>{'# Hello, *world*!'}</Markdown>
+```
+
+### プラグイン付き（本プロジェクトの構成）
+
+```tsx
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import rehypeSanitize from 'rehype-sanitize';
+
+<ReactMarkdown
+  remarkPlugins={[remarkGfm]}
+  rehypePlugins={[rehypeSanitize]}
+>
+  {content}
+</ReactMarkdown>
+```
+
+### プラグインにオプションを渡す
+
+```tsx
+<Markdown remarkPlugins={[[remarkGfm, { singleTilde: false }]]}>
+  {content}
+</Markdown>
+```
+
+### コンポーネントのカスタマイズ
+
+```tsx
+<Markdown
+  components={{
+    h1: ({ children }) => <h1 className="text-3xl font-bold">{children}</h1>,
+    code: ({ children, className }) => {
+      const match = /language-(\w+)/.exec(className || '');
+      return match
+        ? <SyntaxHighlighter language={match[1]}>{String(children)}</SyntaxHighlighter>
+        : <code>{children}</code>;
+    },
+  }}
+>
+  {content}
+</Markdown>
+```
+
+### 利用可能なコンポーネントタグ
+
+**プラグインなし:**
+`a`, `blockquote`, `br`, `code`, `em`, `h1`〜`h6`, `hr`, `img`, `li`, `ol`, `p`, `pre`, `strong`, `ul`
+
+**remark-gfm 追加時:**
+`del`, `input`, `table`, `tbody`, `td`, `th`, `thead`, `tr`
+
+---
+
+## 6. セキュリティ
+
+### デフォルトで安全な点
+
+- `dangerouslySetInnerHTML` を使わない
+- HTML 入力はデフォルトでエスケープまたは無視
+
+### 潜在的リスク
+
+- カスタム `urlTransform` が不適切な場合、XSS の可能性
+- プラグイン自体が安全でない可能性がある
+- `rehype-raw` を使う場合は `rehype-sanitize` との併用が必須
+
+### 本プロジェクトの対策
+
+`rehype-sanitize` をパイプラインに組み込み、すべての出力をサニタイズしている。
+
+---
+
+## 7. バージョン履歴（主な変更）
+
+| バージョン | 主な変更 |
+| --- | --- |
+| **v10.0.0**（2025-02） | `className` prop 削除。ラッパー要素でスタイリング |
+| **v9.1.0**（2025-02） | 非同期プラグインサポート追加（`MarkdownAsync`, `MarkdownHooks`） |
+| **v9.0.0**（2023-09） | `urlTransform` が `transformImageUri`/`transformLinkUri` を統合。`linkTarget` 削除。コンポーネントへの追加 props 削除（code の `inline`、見出しの `level` 等） |
+| **v8.0.0**（2022-01） | `plugins` → `remarkPlugins` にリネーム |
+
+---
+
+## 8. よくあるハマりどころ
+
+### JSX の空白文字折りたたみ
+
+```tsx
+// NG: 改行が失われる
+<Markdown>
+  # Hi
+  Paragraph
+</Markdown>
+
+// OK: 変数に格納
+const md = `# Hi\n\nParagraph`;
+<Markdown>{md}</Markdown>
+```
+
+### Markdown 内の HTML
+
+Markdown 内の HTML はデフォルトでは処理されない。処理したい場合は `rehype-raw` が必要だが、信頼できないソースでは `rehype-sanitize` と併用すること。
+
+### v10 で className が削除
+
+v10 以降、`<Markdown className="...">` は使えない。ラッパー `<div>` でスタイリングする。
+本プロジェクトでは `ReportMarkdown` コンポーネントがラッパー div を提供している。

--- a/docs/markdown-libs/02.remark-gfm.md
+++ b/docs/markdown-libs/02.remark-gfm.md
@@ -1,0 +1,181 @@
+# remark-gfm
+
+GitHub Flavored Markdown（GFM）拡張構文をパース・シリアライズする remark プラグイン。
+標準 CommonMark に加え、テーブル・取り消し線・タスクリスト・オートリンク・脚注を処理できる。
+
+## 基本情報
+
+| 項目 | 値 |
+| --- | --- |
+| npm | `remark-gfm` |
+| 本プロジェクトのバージョン | ^4.0.1 |
+| ライセンス | MIT |
+| モジュール形式 | ESM のみ |
+| リポジトリ | https://github.com/remarkjs/remark-gfm |
+
+---
+
+## 1. GFM（GitHub Flavored Markdown）とは
+
+GFM は GitHub.com で使用される Markdown 方言で、**CommonMark の厳密なスーパーセット**。
+CommonMark の全機能を含みつつ、以下の拡張を追加している。
+
+---
+
+## 2. サポートする GFM 機能
+
+### 2.1 テーブル
+
+パイプ `|` とハイフン `-` で表を作成する。
+
+```markdown
+| 機能       | 説明             | 状態   |
+| ---------- | ---------------- | ------ |
+| テーブル   | パイプ区切り表   | 対応済 |
+| 取り消し線 | チルダで囲む     | 対応済 |
+```
+
+**配置（アライメント）:**
+
+| 記法 | 配置 |
+| --- | --- |
+| `:---` | 左揃え |
+| `---:` | 右揃え |
+| `:---:` | 中央揃え |
+
+**ルール:**
+- セル内のパイプは `\|` でエスケープ
+- ヘッダー行と区切り行のセル数は一致が必要
+- 区切り行には最低3つのハイフン
+
+### 2.2 取り消し線
+
+```markdown
+~~この文は取り消されます~~
+~これも取り消し（singleTilde: true の場合）~
+```
+
+HTML 出力: `<del>この文は取り消されます</del>`
+
+### 2.3 タスクリスト
+
+```markdown
+- [x] 完了したタスク
+- [ ] 未完了のタスク
+```
+
+### 2.4 オートリンク
+
+URL やメールアドレスを自動的にリンクに変換する。
+
+```markdown
+www.example.com
+https://example.com
+contact@example.com
+```
+
+### 2.5 脚注（v3.0.0 で追加）
+
+```markdown
+これは脚注付きのテキストです[^1]。
+
+[^1]: これが脚注の内容です。
+```
+
+---
+
+## 3. API と設定オプション
+
+### 基本的な使い方
+
+```ts
+import remarkGfm from 'remark-gfm';
+
+// react-markdown と組み合わせる場合
+<ReactMarkdown remarkPlugins={[remarkGfm]}>{content}</ReactMarkdown>
+
+// オプション付き
+<ReactMarkdown remarkPlugins={[[remarkGfm, { singleTilde: false }]]}>{content}</ReactMarkdown>
+```
+
+### オプション一覧
+
+| オプション | 型 | デフォルト | 説明 |
+| --- | --- | --- | --- |
+| `singleTilde` | `boolean` | `true` | `~text~` での取り消し線を有効にする。`false` なら `~~text~~` のみ |
+| `stringLength` | `(str) => number` | `d => d.length` | テーブルセルの視覚的な幅を計算する関数 |
+| `tablePipeAlign` | `boolean` | `true` | シリアライズ時にパイプ文字を揃える |
+| `tableCellPadding` | `boolean` | `true` | テーブルセル内にスペースパディングを追加 |
+| `firstLineBlank` | `boolean` | `false` | 脚注定義の最初の行の前に空行を入れる |
+
+### 全角文字のテーブル整列
+
+デフォルトの `stringLength` は文字数ベースのため全角文字の幅を正しく計算できない。
+
+```ts
+import stringWidth from 'string-width';
+// stringLength: stringWidth を指定すると全角文字・絵文字も正しく整列
+```
+
+---
+
+## 4. unified/remark エコシステムでの位置づけ
+
+```
+Markdown文字列
+  → remark-parse     （Markdown → mdast）
+  → remark-gfm       （GFM 拡張のパース）  ← ここ
+  → remark-rehype    （mdast → hast）
+  → rehype-sanitize  （HTML のサニタイズ）
+  → React 要素
+```
+
+remark-gfm 自体は Markdown のパースとシリアライズのみを担当し、HTML 変換は行わない。
+HTML 変換は `remark-rehype` が担当する。
+
+### 関連パッケージ
+
+| パッケージ | 役割 |
+| --- | --- |
+| `micromark-extension-gfm` | 低レベルの GFM パーサー（remark-gfm の内部依存） |
+| `mdast-util-gfm` | GFM 用の AST ユーティリティ |
+| `remark-frontmatter` | YAML/TOML フロントマターのサポート |
+| `remark-breaks` | ソフト改行を `<br>` に変換 |
+| `remark-github` | GitHub 固有の参照リンク（`#123`, `@user` 等） |
+
+---
+
+## 5. バージョン履歴
+
+| バージョン | 主な変更 |
+| --- | --- |
+| **v4.0.0**（2024-09） | Node.js 16+ 必須、型定義更新、`exports` フィールド使用 |
+| **v3.0.0**（2021-10） | **脚注サポート追加**。`remark-footnotes` を使っていた場合は削除が必要 |
+| **v2.0.0**（2021-08） | **ESM に移行**（`require()` 廃止） |
+| **v1.0.0**（2020-10） | 初回安定版リリース |
+
+### マイグレーション時の注意
+
+- **v1→v2**: `require('remark-gfm')` → `import remarkGfm from 'remark-gfm'`
+- **v2→v3**: `remark-footnotes` を削除し `remark-rehype` をアップデート
+- **v3→v4**: Node.js 16+ が必要
+
+---
+
+## 6. よくある問題と解決策
+
+| 問題 | 原因 | 解決策 |
+| --- | --- | --- |
+| テーブルが表示されない | ヘッダーと区切り行のセル数不一致 | 全行でパイプの数を揃え、区切り行に最低3ハイフン |
+| 単一チルダが効かない | 環境差異 | `~~double~~` を使うか `singleTilde: true` を明示 |
+| 全角テーブルが崩れる | `stringLength` がバイト数でなく文字数 | `string-width` パッケージを使用 |
+| ESM インポートエラー | v2+ は ESM のみ | `import` 構文に切り替え |
+| 脚注が動作しない | v3 未満または `remark-rehype` が古い | 最新版にアップデート |
+
+---
+
+## 7. 本プロジェクトでの使用状況
+
+- **ファイル**: `front/src/components/ReportMarkdown.tsx`
+- **構成**: `remarkPlugins={[remarkGfm]}`（オプション指定なし、デフォルト設定）
+- **用途**: テーブル・取り消し線・タスクリスト・オートリンクをレポート本文で表示可能にする

--- a/docs/markdown-libs/03.rehype-sanitize.md
+++ b/docs/markdown-libs/03.rehype-sanitize.md
@@ -1,0 +1,266 @@
+# rehype-sanitize
+
+HTML を安全にするための rehype プラグイン。
+明示的にスキーマで許可されていないものはすべて除去するホワイトリスト方式。
+デフォルトでは GitHub.com のサニタイズ方式に準拠している。
+
+## 基本情報
+
+| 項目 | 値 |
+| --- | --- |
+| npm | `rehype-sanitize` |
+| 本プロジェクトのバージョン | ^6.0.0 |
+| ライセンス | MIT |
+| モジュール形式 | ESM のみ |
+| リポジトリ | https://github.com/rehypejs/rehype-sanitize |
+
+---
+
+## 1. 概要
+
+### 目的
+
+ユーザー入力の Markdown/HTML を安全にレンダリングするため、以下を防御する:
+
+- `<script>` タグの挿入
+- `onclick`, `onmouseover` 等のイベントハンドラ属性
+- `javascript:` プロトコルスキーム
+- `<iframe>` の埋め込み
+- `<img onerror="...">` による XSS
+- DOM Clobbering（`id`/`name` による window プロパティ上書き）
+
+### hast-util-sanitize との関係
+
+- **hast-util-sanitize**: HAST を直接操作するユーティリティ関数（サニタイズの実装本体）
+- **rehype-sanitize**: hast-util-sanitize を unified/rehype パイプラインのプラグインとしてラップしたもの
+
+---
+
+## 2. パイプラインでの配置
+
+```
+Markdown → remark-parse → mdast → remark-rehype → hast → rehype-sanitize → React 要素
+                                                           ↑ ここで動作
+```
+
+**重要**: rehype-sanitize は「最後の信頼できない処理の後」に配置すること。
+rehype-sanitize の後にあるプラグインは信頼できるものだけにする。
+
+```tsx
+// 安全: sanitize がパイプラインの最後
+<ReactMarkdown
+  remarkPlugins={[remarkGfm]}
+  rehypePlugins={[rehypeSanitize]}
+>
+  {content}
+</ReactMarkdown>
+```
+
+---
+
+## 3. デフォルトスキーマ（defaultSchema）
+
+### 許可されるタグ（全54要素）
+
+```
+a, b, blockquote, br, code, dd, del, details, div, dl, dt, em,
+h1, h2, h3, h4, h5, h6, hr, i, img, input, ins, kbd, li, ol, p,
+picture, pre, q, rp, rt, ruby, s, samp, section, source, span,
+strike, strong, sub, summary, sup, table, tbody, td, tfoot, th,
+thead, tr, tt, ul, var
+```
+
+### 要素固有の許可属性（主要なもの）
+
+| 要素 | 許可属性 |
+| --- | --- |
+| `a` | href, className（脚注用）, dataFootnoteBackref, dataFootnoteRef |
+| `code` | className（`/^language-./` パターンのみ） |
+| `img` | src, longDesc, alt（グローバル属性） |
+| `input` | disabled（true 強制）, type（checkbox 強制） |
+| `li` | className（task-list-item） |
+| `ol`, `ul` | className（contains-task-list） |
+| `section` | className（footnotes）, dataFootnotes |
+
+### プロトコル制限
+
+| プロパティ | 許可プロトコル |
+| --- | --- |
+| `cite` | http, https |
+| `href` | http, https, irc, ircs, mailto, xmpp |
+| `src` | http, https |
+
+ローカル URL（`#anchor` 等）は常に許可。
+
+### DOM Clobbering 対策
+
+すべての `id` と `name` 属性に `user-content-` プレフィックスが自動付与される。
+悪意のある要素が `window` プロパティを上書きすることを防止する。
+
+### その他のデフォルト設定
+
+| 設定 | 値 | 説明 |
+| --- | --- | --- |
+| `strip` | `['script']` | script タグの内容は完全除去 |
+| `allowComments` | `false` | HTML コメントは除去 |
+| `allowDoctypes` | `false` | DOCTYPE は除去 |
+
+---
+
+## 4. スキーマのカスタマイズ
+
+### 基本パターン: スプレッド構文
+
+```ts
+import rehypeSanitize, { defaultSchema } from 'rehype-sanitize';
+
+const customSchema = {
+  ...defaultSchema,
+  attributes: {
+    ...defaultSchema.attributes,
+    // カスタマイズ内容を追加
+  },
+};
+```
+
+### react-markdown でカスタムスキーマを渡す
+
+```tsx
+<ReactMarkdown
+  rehypePlugins={[
+    [rehypeSanitize, {
+      ...defaultSchema,
+      attributes: {
+        ...defaultSchema.attributes,
+        '*': [...(defaultSchema.attributes?.['*'] || []), 'className'],
+      },
+    }],
+  ]}
+>
+  {content}
+</ReactMarkdown>
+```
+
+---
+
+## 5. よくあるカスタマイズパターン
+
+### (a) シンタックスハイライト用の className 許可
+
+```ts
+// 言語クラスのみ許可（正規表現）
+{
+  ...defaultSchema,
+  attributes: {
+    ...defaultSchema.attributes,
+    code: [
+      ...(defaultSchema.attributes?.code || []),
+      ['className', /^language-./],
+    ],
+  },
+}
+```
+
+> デフォルトスキーマでは `code` の `className` は `/^language-./` パターンで既に許可済み。
+
+### (b) img タグの追加属性
+
+```ts
+// alt と title を追加許可
+{
+  ...defaultSchema,
+  attributes: {
+    ...defaultSchema.attributes,
+    img: [...(defaultSchema.attributes?.img || []), 'alt', 'title'],
+  },
+}
+```
+
+> `src` はデフォルトで許可済み。`alt` はグローバル属性として許可済み。
+
+### (c) アンカータグに target を追加
+
+```ts
+{
+  ...defaultSchema,
+  attributes: {
+    ...defaultSchema.attributes,
+    a: [...(defaultSchema.attributes?.a || []), 'target', 'rel'],
+  },
+}
+```
+
+### (d) 全要素で className を許可
+
+```ts
+import deepmerge from 'deepmerge';
+const schema = deepmerge(defaultSchema, { attributes: { '*': ['className'] } });
+```
+
+### (e) data 属性を許可
+
+```ts
+{
+  ...defaultSchema,
+  attributes: {
+    ...defaultSchema.attributes,
+    '*': [...(defaultSchema.attributes?.['*'] || []), 'data*'],
+  },
+}
+```
+
+---
+
+## 6. セキュリティモデル
+
+### 基本原則
+
+**ホワイトリスト方式**: 明示的に許可されていないものはすべて除去。
+
+### 防御する攻撃
+
+| 攻撃 | 防御方法 |
+| --- | --- |
+| `<script>` 注入 | タグ自体を除去（strip） |
+| イベントハンドラ XSS | `onclick` 等の属性を除去 |
+| `javascript:` URL | プロトコル制限で除去 |
+| `<iframe>` 埋め込み | 許可タグリストに含まない |
+| DOM Clobbering | `id`/`name` に `user-content-` プレフィックス付与 |
+
+### パイプライン順序の重要性
+
+```
+安全:   parse → sanitize → stringify
+安全:   parse → sanitize → highlight（信頼済み）
+危険:   parse → 信頼できないプラグイン → stringify（sanitize なし）
+```
+
+---
+
+## 7. バージョン履歴
+
+| バージョン | 主な変更 |
+| --- | --- |
+| **v6.0.0** | hast-util-sanitize 更新、GitHub サニタイズ動作準拠、Node.js 16+ 必須 |
+| **v5.0.0** | **ESM に移行**（`require()` 廃止） |
+| **v4.0.0** | TypeScript 型定義の追加 |
+| **v3.0.0** | hast-util-sanitize 依存の更新 |
+
+---
+
+## 8. ベストプラクティス
+
+1. **デフォルトスキーマを基盤にする** — ゼロからスキーマを構築しない。常に `defaultSchema` をベースに拡張
+2. **最小権限の原則** — 必要な属性・タグのみ許可。`'*': ['className']` のような広範な許可は慎重に
+3. **正規表現を活用** — `['className', /^language-./]` のようにパターンマッチで許可値を制限
+4. **プロトコル制限を維持** — `href` に `javascript:` を許可しない
+5. **パイプライン順序を守る** — rehype-sanitize は信頼できないプラグインの後に配置
+
+---
+
+## 9. 本プロジェクトでの使用状況
+
+- **ファイル**: `front/src/components/ReportMarkdown.tsx`
+- **構成**: `rehypePlugins={[rehypeSanitize]}`（デフォルトスキーマ、カスタマイズなし）
+- **用途**: ユーザー入力の Markdown 本文をサニタイズし、XSS を防止
+- **CLAUDE.md の規約**: 「Markdown 表示は `rehype-sanitize` で必ずサニタイズ」と明記

--- a/docs/markdown-libs/README.md
+++ b/docs/markdown-libs/README.md
@@ -1,0 +1,46 @@
+# Markdown ライブラリ調査レポート
+
+本プロジェクトで使用している Markdown レンダリング関連ライブラリの調査レポート。
+
+## 目次
+
+| ファイル | 内容 |
+| --- | --- |
+| [01.react-markdown.md](./01.react-markdown.md) | react-markdown — Markdown → React 変換コンポーネント |
+| [02.remark-gfm.md](./02.remark-gfm.md) | remark-gfm — GitHub Flavored Markdown 拡張プラグイン |
+| [03.rehype-sanitize.md](./03.rehype-sanitize.md) | rehype-sanitize — HTML サニタイズプラグイン |
+
+## 全体像
+
+本プロジェクトでは以下の3ライブラリを組み合わせて Markdown を安全にレンダリングしている。
+
+```
+Markdown文字列
+  → remark-parse（Markdown → mdast）
+  → remark-gfm（GFM 拡張の解析）
+  → remark-rehype（mdast → hast）
+  → rehype-sanitize（hast のサニタイズ）
+  → React 要素としてレンダリング
+```
+
+### 使用箇所
+
+- `front/src/components/ReportMarkdown.tsx`
+
+```tsx
+<ReactMarkdown
+  remarkPlugins={[remarkGfm]}
+  rehypePlugins={[rehypeSanitize]}
+  components={{ /* カスタムコンポーネント */ }}
+>
+  {content}
+</ReactMarkdown>
+```
+
+### 使用バージョン
+
+| ライブラリ | バージョン |
+| --- | --- |
+| react-markdown | ^10.1.0 |
+| remark-gfm | ^4.0.1 |
+| rehype-sanitize | ^6.0.0 |


### PR DESCRIPTION
## Summary
- `docs/markdown-libs/` フォルダを新規作成し、Markdown レンダリング関連ライブラリの調査レポートを追加
- 対象: react-markdown / remark-gfm / rehype-sanitize
- 各ライブラリの API・設定・セキュリティ・バージョン履歴・ハマりどころを網羅
- `docs/README.md` にフォルダへのリンクを追加

## Test plan
- [ ] ドキュメントのみの変更のため、ビルド・E2E への影響なし
- [ ] 各 .md ファイルの内容とリンクを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)