### PR TITLE
Add RLS policies for ReportTag/ReportTagMapping

### DIFF
--- a/docs/03.requirements.md
+++ b/docs/03.requirements.md
@@ -34,6 +34,20 @@
   - RLS方針: Reportは公開閲覧、認証ユーザーのみ書き込み可能
 - 管理者メールは環境変数 `ADMIN_EMAIL` の一致のみ許可（複数指定はカンマ区切り）。
 
+## RLSポリシー（Supabase Row Level Security）
+
+全テーブルで RLS 有効。ポリシーは `auth.uid() IS NOT NULL` で認証判定。
+
+| テーブル | SELECT | INSERT | UPDATE | DELETE |
+|---|---|---|---|---|
+| `Report` | 誰でも (`true`) | 認証ユーザー | 認証ユーザー | 認証ユーザー |
+| `ReportTag` | 誰でも (`true`) | 認証ユーザー | — | — |
+| `ReportTagMapping` | 誰でも (`true`) | 認証ユーザー | — | 認証ユーザー |
+
+- SELECT は未ログインでも許可（公開閲覧）。
+- INSERT/UPDATE/DELETE は Supabase Auth の認証セッションが必要。
+- 管理者の細かい判定は RLS ではなくサーバーサイドAPI（`/api/auth/is-allowed`）で実施。
+
 ## 非機能要件
 - デプロイ: 本番運用はVercelで実施（デプロイ必須）。
 - CI/CD: 自動デプロイのみ（Vercel連携を前提）。`main` ブランチのみ、本番デプロイ。プレビューは不要。

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -64,6 +64,7 @@
 - [x] Report/Userスキーマを確定
 - [x] 投稿/編集/削除のデータ連携
 - [x] Prismaスキーマは既存テーブルを `prisma db pull` で取得し、新規設計は `schema.prisma` に記述（マイグレーション禁止）
+- [x] RLSポリシーを全テーブル（Report/ReportTag/ReportTagMapping）に設定（公開閲覧 + 認証ユーザーのみ書き込み / 2026-03-22）
 
 ## テスト
 - [x] E2Eテスト基盤を導入


### PR DESCRIPTION
## Summary
- ReportTag / ReportTagMapping テーブルにRLSポリシーを追加（Supabase SQL実行済み）
- 要件定義ドキュメント (`docs/03.requirements.md`) にRLSポリシー一覧テーブルを追加
- タスク管理 (`docs/TASKS.md`) にRLS設定完了を記録

## 背景
- Report テーブルにはRLSポリシーが設定済みだったが、ReportTag / ReportTagMapping はRLS有効なのにポリシー未設定（= 全アクセス拒否状態）だった
- 今回 SELECT (公開) + INSERT/DELETE (認証ユーザー) のポリシーを追加し、タグ関連の操作を正常化

## 適用済みRLSポリシー

| テーブル | SELECT | INSERT | UPDATE | DELETE |
|---|---|---|---|---|
| Report | 誰でも | 認証ユーザー | 認証ユーザー | 認証ユーザー |
| ReportTag | 誰でも | 認証ユーザー | — | — |
| ReportTagMapping | 誰でも | 認証ユーザー | — | 認証ユーザー |

## Test plan
- [ ] 未ログイン状態でレポート一覧・詳細が閲覧できること
- [ ] ログイン状態でレポートの投稿・編集・削除ができること
- [ ] ログイン状態でタグ付きレポートの投稿・編集ができること
- [ ] サイドバーのタグ一覧が正常に表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)