### PR TITLE
Fix: postinstallでprisma generateを実行（Vercel 500エラー修正）

### DIFF
--- a/front/package.json
+++ b/front/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
+    "postinstall": "prisma generate",
     "build": "next build",
     "start": "next start",
     "lint": "eslint",


### PR DESCRIPTION
## Summary
- `postinstall` スクリプトに `prisma generate` を追加
- Vercelのビルドキャッシュから `node_modules` が復元された場合に Prisma Client が生成されず、`/api/reports` と `/api/tags` が 500 エラーになる問題を修正

## Root cause
Prisma v6 の `@prisma/client` は `npm install` 時に自動で `prisma generate` を実行するが、Vercel がキャッシュから `node_modules` を復元すると `install` がスキップされ、Prisma Client が未生成のままビルド・デプロイされる。

## Test plan
- [x] `npm run build` 成功
- [ ] Vercelデプロイ後に `/api/reports` と `/api/tags` が 200 を返すことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)