### PR TITLE
Fix: prisma.config.tsにDATABASE_URLフォールバック追加（CI修正）

### DIFF
--- a/front/prisma.config.ts
+++ b/front/prisma.config.ts
@@ -1,11 +1,11 @@
 import { config } from 'dotenv';
-import { defineConfig, env } from 'prisma/config';
+import { defineConfig } from 'prisma/config';
 
 config({ path: '.env.local' });
 
 export default defineConfig({
   schema: 'prisma/schema.prisma',
   datasource: {
-    url: env('DATABASE_URL'),
+    url: process.env.DATABASE_URL ?? 'postgresql://placeholder:placeholder@localhost:5432/placeholder',
   },
 });


### PR DESCRIPTION
## Summary
- `prisma.config.ts` の `env('DATABASE_URL')` を `process.env.DATABASE_URL ?? placeholder` に変更
- CIで `DATABASE_URL` 未設定時に `postinstall` の `prisma generate` が失敗する問題を修正

## Root cause
PR #45 で `postinstall: prisma generate` を追加したが、`prisma.config.ts` が `env('DATABASE_URL')` で必須チェックしており、CI（E2Eジョブ）で `DATABASE_URL` が未設定のため例外が発生。

## Test plan
- [x] `npm run build` 成功
- [ ] CI E2Eジョブが `npm ci` を通過することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)