### PR TITLE
一覧APIからcontent除外 + CDNキャッシュ + useReportフック追加

### DIFF
--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -84,6 +84,8 @@
 - [x] PrismaClientを本番でもグローバル再利用に変更（コールドスタート時のDB再接続削減 / 2026-03-23）
 - [x] Supabaseクライアントをモジュールスコープで初期化に変更（`auth-server.ts`, `api/auth/admin` / 2026-03-23）
 - [x] 詳細・編集ページをSSG（静的生成）に変更しCDNキャッシュ配信に移行（`/report/[id]`, `/report/[id]/edit` / 2026-03-23）
+- [x] 一覧APIからcontent除外（2.2MB→~76KB）+ 詳細を`useReport`フックで個別取得（2026-03-23）
+- [x] GET API（reports/tags/reports/[id]）にCDNキャッシュヘッダー追加（`s-maxage=60, stale-while-revalidate=300` / 2026-03-23）
 
 ## 残タスク
 - [x] allowedDevOrigins 警告の対応

--- a/front/src/app/api/reports/[id]/route.ts
+++ b/front/src/app/api/reports/[id]/route.ts
@@ -41,7 +41,9 @@ export async function GET(_request: NextRequest, { params }: RouteParams) {
       return NextResponse.json({ error: 'Not found' }, { status: 404 });
     }
 
-    return NextResponse.json(toReportItem(report));
+    return NextResponse.json(toReportItem(report), {
+      headers: { 'Cache-Control': 's-maxage=60, stale-while-revalidate=300' },
+    });
   } catch (error) {
     console.error('[api/reports/[id]] GET failed', error);
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 });

--- a/front/src/app/api/reports/route.ts
+++ b/front/src/app/api/reports/route.ts
@@ -4,9 +4,13 @@ import { prisma } from '@/lib/db';
 import { validateReportInput } from '@/lib/validation';
 import { requireAdmin } from '@/lib/auth-server';
 
-type ReportWithTags = Report & {
-  ReportTagMapping: (ReportTagMapping & { ReportTag: ReportTag })[];
-};
+type TagMapping = ReportTagMapping & { ReportTag: ReportTag };
+
+type ReportWithTags = Report & { ReportTagMapping: TagMapping[] };
+
+type ReportListRow = Omit<Report, 'content'> & { ReportTagMapping: TagMapping[] };
+
+const mapTags = (mappings: TagMapping[]) => mappings.map((m) => m.ReportTag.name);
 
 const toReportItem = (report: ReportWithTags) => ({
   id: report.id,
@@ -18,7 +22,20 @@ const toReportItem = (report: ReportWithTags) => ({
   publishDate: report.publishDate?.toISOString() ?? null,
   createdAt: report.createdAt.toISOString(),
   updatedAt: report.updatedAt.toISOString(),
-  tags: report.ReportTagMapping.map((m) => m.ReportTag.name),
+  tags: mapTags(report.ReportTagMapping),
+});
+
+const toReportListItem = (report: ReportListRow) => ({
+  id: report.id,
+  title: report.title,
+  summary: report.summary ?? null,
+  content: '',
+  category: report.category,
+  author: report.author,
+  publishDate: report.publishDate?.toISOString() ?? null,
+  createdAt: report.createdAt.toISOString(),
+  updatedAt: report.updatedAt.toISOString(),
+  tags: mapTags(report.ReportTagMapping),
 });
 
 const parseNumber = (value: string | null, range: { min?: number; max?: number } = {}) => {
@@ -43,7 +60,15 @@ export async function GET(request: NextRequest) {
         orderBy: { createdAt: 'desc' },
         ...(limit !== undefined ? { take: limit } : {}),
         skip: offset,
-        include: {
+        select: {
+          id: true,
+          title: true,
+          summary: true,
+          category: true,
+          author: true,
+          publishDate: true,
+          createdAt: true,
+          updatedAt: true,
           ReportTagMapping: {
             include: { ReportTag: true },
           },
@@ -59,7 +84,8 @@ export async function GET(request: NextRequest) {
       headers['x-offset'] = String(offset);
     }
 
-    return NextResponse.json(reports.map(toReportItem), { headers });
+    headers['Cache-Control'] = 's-maxage=60, stale-while-revalidate=300';
+    return NextResponse.json(reports.map(toReportListItem), { headers });
   } catch (error) {
     console.error('[api/reports] GET failed', error);
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 });

--- a/front/src/app/api/tags/route.ts
+++ b/front/src/app/api/tags/route.ts
@@ -7,7 +7,9 @@ export async function GET() {
       orderBy: { name: 'asc' },
       select: { name: true },
     });
-    return NextResponse.json(tags.map((t) => t.name));
+    return NextResponse.json(tags.map((t) => t.name), {
+      headers: { 'Cache-Control': 's-maxage=60, stale-while-revalidate=300' },
+    });
   } catch (error) {
     console.error('[api/tags] GET failed', error);
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 });

--- a/front/src/app/report/[id]/client.tsx
+++ b/front/src/app/report/[id]/client.tsx
@@ -4,12 +4,14 @@ import { useParams } from 'next/navigation';
 import AppShell from '@/components/organisms/AppShell';
 import DetailPage from '@/components/pages/DetailPage';
 import { useAppState } from '@/hooks/useAppState';
+import { useReport } from '@/hooks/useReport';
 
 export default function ReportDetailClient() {
   const params = useParams();
   const { theme, reports, currentUser, deleteReport } = useAppState();
   const reportId = Array.isArray(params.id) ? params.id[0] : params.id;
-  const report = reports.find((item) => item.id === reportId);
+  const listReport = reports.find((item) => item.id === reportId);
+  const { report } = useReport(reportId, listReport);
 
   return (
     <AppShell>

--- a/front/src/app/report/[id]/edit/client.tsx
+++ b/front/src/app/report/[id]/edit/client.tsx
@@ -4,19 +4,25 @@ import { useParams } from 'next/navigation';
 import AppShell from '@/components/organisms/AppShell';
 import FormPage from '@/components/pages/FormPage';
 import { useAppState } from '@/hooks/useAppState';
+import { useReport } from '@/hooks/useReport';
 
 export default function ReportEditClient() {
   const params = useParams();
   const { theme, reports, currentUser, updateReport, isHydrated } = useAppState();
   const reportId = Array.isArray(params.id) ? params.id[0] : params.id;
+  const listReport = reports.find((item) => item.id === reportId);
+  const { report } = useReport(reportId, listReport);
 
   if (!reportId) return null;
+
+  // Pass the full report (with content) as a single-item array for useReportForm lookup
+  const reportsForForm = report ? [report] : [];
 
   return (
     <AppShell>
       <FormPage
         theme={theme}
-        reports={reports}
+        reports={reportsForForm}
         onSubmit={(data) => updateReport(reportId, data)}
         user={currentUser}
         reportId={reportId}

--- a/front/src/hooks/index.ts
+++ b/front/src/hooks/index.ts
@@ -2,4 +2,5 @@ export { useAppState } from './useAppState';
 export { useLoading } from './useLoading';
 export { useLoginForm } from './useLoginForm';
 export { usePagination } from './usePagination';
+export { useReport } from './useReport';
 export { useReportForm } from './useReportForm';

--- a/front/src/hooks/useReport.ts
+++ b/front/src/hooks/useReport.ts
@@ -1,0 +1,53 @@
+import { useEffect, useState } from 'react';
+import { ReportItem } from '@/types';
+
+/**
+ * Fetches a single report with full content from /api/reports/[id].
+ * Returns the cached report from the list (without content) immediately,
+ * then replaces it with the full report once the API responds.
+ */
+export const useReport = (
+  reportId: string | undefined,
+  listReport: ReportItem | undefined,
+) => {
+  const [report, setReport] = useState<ReportItem | undefined>(listReport);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const dataMode = process.env.NEXT_PUBLIC_DATA_MODE ?? 'supabase';
+
+  useEffect(() => {
+    if (!reportId) return;
+
+    // In local mode, the list already has full content
+    if (dataMode === 'local') {
+      setReport(listReport);
+      return;
+    }
+
+    // If list report already has content (optimistic update after create/edit),
+    // use it directly without fetching
+    if (listReport?.content) {
+      setReport(listReport);
+      return;
+    }
+
+    // Show list metadata immediately while fetching full content
+    if (listReport) {
+      setReport(listReport);
+    }
+
+    setIsLoading(true);
+    fetch(`/api/reports/${reportId}`)
+      .then((res) => {
+        if (!res.ok) return undefined;
+        return res.json();
+      })
+      .then((data: ReportItem | undefined) => {
+        if (data) setReport(data);
+      })
+      .catch(() => {})
+      .finally(() => setIsLoading(false));
+  }, [reportId, listReport?.id, listReport?.content, dataMode]);
+
+  return { report, isLoading };
+};


### PR DESCRIPTION
## Summary
- `GET /api/reports` からcontent（Markdown本文）を除外し、レスポンスを **2.2MB → ~76KB** に削減
- DBクエリも `select` でcontent列をスキップし、クエリ自体を高速化
- 詳細・編集ページは新規 `useReport` フックで `GET /api/reports/[id]` から個別取得
- 全GET APIに `Cache-Control: s-maxage=60, stale-while-revalidate=300` を追加（CDNキャッシュ）

## Why
本番サイトで `/api/reports` のTTFBが **3.4秒**（ウォームスタートでも同様）。
原因は218件のレポートのMarkdown本文（93%のペイロード）を毎回全件取得していたため。

| 指標 | Before | After |
|------|--------|-------|
| `/api/reports` レスポンスサイズ | 2.2MB | ~76KB |
| content取得 | 全件一括 | 詳細/編集時のみ1件 |
| CDNキャッシュ | なし | 60秒 + stale-while-revalidate 5分 |

## useReport フック設計
- 一覧のメタデータ（title, summary等）を即座に表示
- contentのみ `/api/reports/[id]` から非同期取得
- ローカルモード（E2E）では一覧データをそのまま使用
- 楽観的更新後（content付き）は再fetchしない

## Test plan
- [x] `npm run build` 成功
- [x] E2E全15テスト合格
- [ ] Vercelデプロイ後、`/api/reports` のレスポンスサイズとTTFBを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)