### PR TITLE
POST/PATCHトランザクション最適化: 不要クエリ削除

### DIFF
--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -86,6 +86,7 @@
 - [x] 詳細・編集ページをSSG（静的生成）に変更しCDNキャッシュ配信に移行（`/report/[id]`, `/report/[id]/edit` / 2026-03-23）
 - [x] 一覧APIからcontent除外（2.2MB→~76KB）+ 詳細を`useReport`フックで個別取得（2026-03-23）
 - [x] GET API（reports/tags/reports/[id]）にCDNキャッシュヘッダー追加（`s-maxage=60, stale-while-revalidate=300` / 2026-03-23）
+- [x] POST/PATCHトランザクション最適化: 不要クエリ削除 + upsert結果直接利用（DB呼び出し数 N+5→N+2 / 2026-03-23）
 
 ## 残タスク
 - [x] allowedDevOrigins 警告の対応

--- a/front/src/app/api/reports/[id]/route.ts
+++ b/front/src/app/api/reports/[id]/route.ts
@@ -79,23 +79,24 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
         },
       });
 
+      let tags: string[] | undefined;
       if (hasDataField(data, 'tags') && data.tags) {
         const tagNames = data.tags;
 
         await tx.reportTagMapping.deleteMany({ where: { reportId: id } });
 
+        let tagRecords: { id: string; name: string }[] = [];
         if (tagNames.length > 0) {
-          for (const tagName of tagNames) {
-            await tx.reportTag.upsert({
-              where: { name: tagName },
-              create: { id: crypto.randomUUID(), name: tagName },
-              update: {},
-            });
-          }
-
-          const tagRecords = await tx.reportTag.findMany({
-            where: { name: { in: tagNames } },
-          });
+          tagRecords = await Promise.all(
+            tagNames.map((tagName) =>
+              tx.reportTag.upsert({
+                where: { name: tagName },
+                create: { id: crypto.randomUUID(), name: tagName },
+                update: {},
+                select: { id: true, name: true },
+              }),
+            ),
+          );
 
           await tx.reportTagMapping.createMany({
             data: tagRecords.map((tag) => ({
@@ -105,19 +106,36 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
             })),
           });
         }
+        tags = tagRecords.map((t) => t.name);
       }
 
-      return tx.report.findUniqueOrThrow({
-        where: { id: report.id },
-        include: {
-          ReportTagMapping: {
-            include: { ReportTag: true },
-          },
-        },
-      });
+      return { report, tags };
     });
 
-    return NextResponse.json(toReportItem(result));
+    // If tags were not updated, fetch current tags
+    const tags =
+      result.tags ??
+      (
+        await prisma.reportTagMapping.findMany({
+          where: { reportId: id },
+          include: { ReportTag: true },
+        })
+      ).map((m) => m.ReportTag.name);
+
+    const item = {
+      id: result.report.id,
+      title: result.report.title,
+      summary: result.report.summary ?? null,
+      content: result.report.content,
+      category: result.report.category,
+      author: result.report.author,
+      publishDate: result.report.publishDate?.toISOString() ?? null,
+      createdAt: result.report.createdAt.toISOString(),
+      updatedAt: result.report.updatedAt.toISOString(),
+      tags,
+    };
+
+    return NextResponse.json(item);
   } catch (error) {
     console.error('[api/reports/[id]] PATCH failed', error);
     const code = typeof error === 'object' && error !== null && 'code' in error ? error.code : null;

--- a/front/src/app/api/reports/route.ts
+++ b/front/src/app/api/reports/route.ts
@@ -118,18 +118,18 @@ export async function POST(request: NextRequest) {
         },
       });
 
+      let tagRecords: { id: string; name: string }[] = [];
       if (tagNames.length > 0) {
-        for (const tagName of tagNames) {
-          await tx.reportTag.upsert({
-            where: { name: tagName },
-            create: { id: crypto.randomUUID(), name: tagName },
-            update: {},
-          });
-        }
-
-        const tagRecords = await tx.reportTag.findMany({
-          where: { name: { in: tagNames } },
-        });
+        tagRecords = await Promise.all(
+          tagNames.map((tagName) =>
+            tx.reportTag.upsert({
+              where: { name: tagName },
+              create: { id: crypto.randomUUID(), name: tagName },
+              update: {},
+              select: { id: true, name: true },
+            }),
+          ),
+        );
 
         await tx.reportTagMapping.createMany({
           data: tagRecords.map((tag) => ({
@@ -140,17 +140,23 @@ export async function POST(request: NextRequest) {
         });
       }
 
-      return tx.report.findUniqueOrThrow({
-        where: { id: report.id },
-        include: {
-          ReportTagMapping: {
-            include: { ReportTag: true },
-          },
-        },
-      });
+      return { report, tags: tagRecords.map((t) => t.name) };
     });
 
-    return NextResponse.json(toReportItem(result), { status: 201 });
+    const item = {
+      id: result.report.id,
+      title: result.report.title,
+      summary: result.report.summary ?? null,
+      content: result.report.content,
+      category: result.report.category,
+      author: result.report.author,
+      publishDate: result.report.publishDate?.toISOString() ?? null,
+      createdAt: result.report.createdAt.toISOString(),
+      updatedAt: result.report.updatedAt.toISOString(),
+      tags: result.tags,
+    };
+
+    return NextResponse.json(item, { status: 201 });
   } catch (error) {
     console.error('[api/reports] POST failed', error);
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 });


### PR DESCRIPTION
## Summary
- タグupsertの結果を直接利用し、別途 `findMany` を削除
- トランザクション末尾の `findUniqueOrThrow`（JOIN付き）を削除、手元のデータからレスポンスを構築
- タグupsertを `Promise.all` で実行（逐次ループから変更）
- DB呼び出し数: タグN個で **N+5 → N+2** に削減

## Before / After (タグ5個の場合)

| Before | After |
|--------|-------|
| `report.create` (1) | `report.create` (1) |
| `reportTag.upsert` × 5 (逐次) | `reportTag.upsert` × 5 (`Promise.all`) |
| `reportTag.findMany` (1) | ~~削除~~ |
| `reportTagMapping.createMany` (1) | `reportTagMapping.createMany` (1) |
| `report.findUniqueOrThrow` + JOIN (1) | ~~削除~~ |
| **計 9 DB呼び出し** | **計 7 DB呼び出し** |

## Test plan
- [x] `npm run build` 成功
- [x] E2E全15テスト合格
- [ ] Vercelデプロイ後、POST /api/reports のレスポンス時間を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)