### PR TITLE
Fix: POST/PATCH エラー修正 — Promise.allを逐次処理に戻す

### DIFF
--- a/front/src/app/api/reports/[id]/route.ts
+++ b/front/src/app/api/reports/[id]/route.ts
@@ -87,16 +87,15 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
 
         let tagRecords: { id: string; name: string }[] = [];
         if (tagNames.length > 0) {
-          tagRecords = await Promise.all(
-            tagNames.map((tagName) =>
-              tx.reportTag.upsert({
-                where: { name: tagName },
-                create: { id: crypto.randomUUID(), name: tagName },
-                update: {},
-                select: { id: true, name: true },
-              }),
-            ),
-          );
+          for (const tagName of tagNames) {
+            const tag = await tx.reportTag.upsert({
+              where: { name: tagName },
+              create: { id: crypto.randomUUID(), name: tagName },
+              update: {},
+              select: { id: true, name: true },
+            });
+            tagRecords.push(tag);
+          }
 
           await tx.reportTagMapping.createMany({
             data: tagRecords.map((tag) => ({

--- a/front/src/app/api/reports/route.ts
+++ b/front/src/app/api/reports/route.ts
@@ -120,16 +120,15 @@ export async function POST(request: NextRequest) {
 
       let tagRecords: { id: string; name: string }[] = [];
       if (tagNames.length > 0) {
-        tagRecords = await Promise.all(
-          tagNames.map((tagName) =>
-            tx.reportTag.upsert({
-              where: { name: tagName },
-              create: { id: crypto.randomUUID(), name: tagName },
-              update: {},
-              select: { id: true, name: true },
-            }),
-          ),
-        );
+        for (const tagName of tagNames) {
+          const tag = await tx.reportTag.upsert({
+            where: { name: tagName },
+            create: { id: crypto.randomUUID(), name: tagName },
+            update: {},
+            select: { id: true, name: true },
+          });
+          tagRecords.push(tag);
+        }
 
         await tx.reportTagMapping.createMany({
           data: tagRecords.map((tag) => ({


### PR DESCRIPTION
## Summary
- Prismaインタラクティブトランザクション内の `Promise.all` を逐次ループに戻す
- トランザクションは単一DB接続を使うため、並列操作がエラーを引き起こしていた

## 原因
PR #51 で `Promise.all` を導入したが、Prismaのインタラクティブトランザクション（`$transaction(async (tx) => ...)`)は単一接続で動作するため、並列クエリが競合しエラー発生。

## 修正
- `Promise.all(tagNames.map(...))` → `for...of` ループに戻す
- `findMany`/`findUniqueOrThrow` の削除は維持（これらは問題なし）

## Test plan
- [x] `npm run build` 成功
- [x] E2E全15テスト合格
- [ ] Vercelデプロイ後、POST /api/reports が201を返すことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)