### PR TITLE
Fix: #47レビュー指摘対応 — 設計書同期 + 300ms定数統一

### DIFF
--- a/docs/06.api-routes-design.md
+++ b/docs/06.api-routes-design.md
@@ -309,7 +309,10 @@ youtube-my-collection/front/src/
 
 ### 1. `front/src/lib/auth-server.ts` — サーバー側認可ミドルウェア
 
-youtube-my-collection の `auth-server.ts` を踏襲。
+youtube-my-collection の `auth-server.ts` をベースに、以下のパフォーマンス改善を追加（#47）:
+- Supabase クライアントをモジュールスコープで生成し warm invocation 間で再利用
+- 認証済みトークンをインメモリキャッシュ（TTL 5分）し、同一トークンの2回目以降は Supabase HTTP 往復をスキップ
+- `supabase.auth.getUser(token)` は明示的に JWT を渡すため、共有クライアントでも auth 状態の混線は起きない
 
 ```typescript
 import { NextRequest, NextResponse } from 'next/server';
@@ -318,6 +321,15 @@ import { createClient } from '@supabase/supabase-js';
 type RequireAdminResult =
   | { ok: true; email: string }
   | { ok: false; response: NextResponse };
+
+// モジュールスコープで生成し warm invocation 間で再利用
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL ?? '';
+const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? '';
+const supabaseAdmin = createClient(supabaseUrl, supabaseAnonKey);
+
+// 認証済みトークンのインメモリキャッシュ（warm invocation 間で存続）
+const authCache = new Map<string, { email: string; expiresAt: number }>();
+const AUTH_CACHE_TTL = 5 * 60 * 1000; // 5 minutes
 
 // ログ出力時のメールマスク
 const maskEmail = (value: string) => {
@@ -339,15 +351,21 @@ export const requireAdmin = async (
     return { ok: false, response: NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) };
   }
 
-  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL ?? '';
-  const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? '';
   const adminEmails = (process.env.ADMIN_EMAIL ?? '')
     .split(',')
     .map((e) => e.trim().toLowerCase())
     .filter(Boolean);
-  const supabase = createClient(supabaseUrl, supabaseAnonKey);
 
-  const { data: authData, error: authError } = await supabase.auth.getUser(token);
+  // キャッシュヒット時は Supabase HTTP 往復をスキップ
+  const cached = authCache.get(token);
+  if (cached && cached.expiresAt > Date.now()) {
+    if (adminEmails.includes(cached.email.toLowerCase())) {
+      return { ok: true, email: cached.email };
+    }
+    return { ok: false, response: NextResponse.json({ error: 'Forbidden' }, { status: 403 }) };
+  }
+
+  const { data: authData, error: authError } = await supabaseAdmin.auth.getUser(token);
   const email = authData?.user?.email ?? '';
   const emailMatches = adminEmails.includes(email.toLowerCase());
 
@@ -360,16 +378,32 @@ export const requireAdmin = async (
     return { ok: false, response: NextResponse.json({ error: 'Forbidden' }, { status: 403 }) };
   }
 
+  // 検証成功をキャッシュ
+  authCache.set(token, { email, expiresAt: Date.now() + AUTH_CACHE_TTL });
+
+  // メモリリーク防止: 100件超で期限切れエントリを削除
+  if (authCache.size > 100) {
+    const now = Date.now();
+    for (const [key, val] of authCache) {
+      if (val.expiresAt <= now) authCache.delete(key);
+    }
+  }
+
   return { ok: true, email };
 };
 ```
 
 **youtube版との差分:**
 - `ADMIN_EMAIL` をカンマ区切りで複数対応（md-viewの既存仕様を維持）
+- Supabase クライアントをモジュールスコープで再利用（youtube版はリクエストごと生成）
+- 認証トークンのインメモリキャッシュを追加（TTL 5分、最大100件で自動evict）
 
 ### 2. `front/src/lib/db.ts` — Prismaクライアントシングルトン
 
-youtube-my-collection の `db.ts` をそのまま踏襲。
+youtube-my-collection の `db.ts` をベースに、本番でもグローバル再利用する形に変更。
+Vercel Serverless では同一プロセスが複数リクエストを処理する（warm invocation）ため、
+リクエストごとに `new PrismaClient()` するとコールドスタートに近いコストが毎回発生する。
+`globalThis` に保持することで warm invocation 時のDB再接続を削減する。
 
 ```typescript
 import { PrismaClient } from '@prisma/client';
@@ -386,9 +420,8 @@ export const prisma =
     log: ['error'],
   });
 
-if (process.env.NODE_ENV !== 'production') {
-  globalForPrisma.prisma = prisma;
-}
+// 本番・開発とも globalThis に保持して warm invocation 間で再利用する
+globalForPrisma.prisma = prisma;
 ```
 
 ### 3. `front/src/lib/validation.ts` — サーバー+クライアント共用バリデーション
@@ -620,7 +653,15 @@ Response: { isAdmin: boolean }
 - この区別は youtube-my-collection と同じ設計: `/api/auth/admin` は `supabase.auth.getUser(token)` + メール照合のみ、`requireAdmin()` は 401/403 でブロック。
 
 **実装概要（requireAdmin を使わない）:**
+
+Supabase クライアントはモジュールスコープで生成し、warm invocation 間で再利用する。
+`supabase.auth.getUser(token)` は明示的に JWT を渡すため、共有 auth 状態の混線は起きない。
+
 ```typescript
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL ?? '';
+const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? '';
+const supabase = createClient(supabaseUrl, supabaseAnonKey);
+
 export async function GET(request: Request) {
   const authHeader = request.headers.get('authorization');
   const token = authHeader ? authHeader.replace(/^Bearer\s+/i, '').trim() : '';
@@ -629,7 +670,6 @@ export async function GET(request: Request) {
     return NextResponse.json({ isAdmin: false }, { status: 401 });
   }
 
-  const supabase = createClient(supabaseUrl, supabaseAnonKey);
   const { data, error } = await supabase.auth.getUser(token);
   if (error || !data.user) {
     return NextResponse.json({ isAdmin: false }, { status: 401 });

--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -89,6 +89,8 @@
 - [x] POST/PATCHトランザクション最適化: 不要クエリ削除 + upsert結果直接利用（DB呼び出し数 N+5→N+2 / 2026-03-23）
 - [x] requireAdmin()の認証結果をメモリキャッシュ（同一トークンの2回目以降はSupabase HTTP往復スキップ / 2026-03-23）
 - [x] mutation後のfetchTags()を廃止しderiveTagsFromReportsに統一（不要なAPI呼び出し排除 / 2026-03-23）
+- [x] #47レビュー指摘対応: 設計書のPrisma/Supabaseシングルトン記述を実装に合わせて更新（`docs/06.api-routes-design.md` / 2026-03-23）
+- [x] #47レビュー指摘対応: AppShellのローディング300ms定数を一元管理に変更（2026-03-23）
 
 ## 残タスク
 - [x] allowedDevOrigins 警告の対応

--- a/front/src/components/organisms/AppShell.tsx
+++ b/front/src/components/organisms/AppShell.tsx
@@ -27,6 +27,7 @@ const AppShell = ({ children }: { children: React.ReactNode }) => {
   const loadingStartRef = useRef<number | null>(null);
   const loadingTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const lastManualTriggerRef = useRef<number | null>(null);
+  /** ローディング最短表示時間（ms）— 手動トリガー抑止の閾値と共用 */
   const minDurationMs = 300;
 
   useEffect(() => {
@@ -63,7 +64,7 @@ const AppShell = ({ children }: { children: React.ReactNode }) => {
 
   useEffect(() => {
     const now = Date.now();
-    if (lastManualTriggerRef.current && now - lastManualTriggerRef.current < 300) {
+    if (lastManualTriggerRef.current && now - lastManualTriggerRef.current < minDurationMs) {
       return;
     }
     startLoading();


### PR DESCRIPTION
## Summary
- `docs/06.api-routes-design.md` のPrismaシングルトン・Supabaseクライアント・認証キャッシュの記述を実装に合わせて更新
- `AppShell.tsx` の手動トリガー抑止用ハードコード `300` を `minDurationMs` 定数に統一
- `docs/TASKS.md` にレビュー指摘対応タスクを追記

Refs #47

## Test plan
- [x] `npm run build` 成功確認済み
- [ ] E2E全テスト合格（ドキュメント変更 + 定数参照のみのため機能影響なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)