### PR TITLE
Fix white screen flash after initial loading

### DIFF
--- a/front/src/components/organisms/AppShell.tsx
+++ b/front/src/components/organisms/AppShell.tsx
@@ -58,7 +58,9 @@ const AppShell = ({ children }: { children: React.ReactNode }) => {
   useEffect(() => {
     if (!isHydrated) return;
     const elapsed = Date.now() - (loadingStartRef.current ?? Date.now());
-    const remaining = Math.max(0, minDurationMs - elapsed);
+    /** コンテンツfade-inが先行するよう、オーバーレイfade-outに最低200msの猶予を確保 */
+    const renderBufferMs = 200;
+    const remaining = Math.max(renderBufferMs, minDurationMs - elapsed);
     scheduleFadeOut(remaining);
   }, [isHydrated]);
 


### PR DESCRIPTION
## Summary
- 初回ロード時、API fetchがminDurationMs(300ms)を超えると`remaining=0`となりオーバーレイが即座にフェードアウトし、コンテンツfade-inが追いつかず白画面が発生していた
- `isHydrated=true`後に最低200msのレンダリングバッファを確保し、コンテンツのfade-inが先行するよう修正

## 変更内容
```diff
- const remaining = Math.max(0, minDurationMs - elapsed);
+ const renderBufferMs = 200;
+ const remaining = Math.max(renderBufferMs, minDurationMs - elapsed);
```

## 修正前後の動作
| API応答時間 | 修正前(remaining) | 修正後(remaining) |
|---|---|---|
| 200ms | 100ms | **200ms** |
| 500ms | 0ms (白画面) | **200ms** |
| 1000ms | 0ms (白画面) | **200ms** |

## Test plan
- [ ] 初回ロードでローディング→白画面→表示のギャップが解消されていること
- [ ] ルート遷移（詳細→一覧）でも白画面が出ないこと
- [ ] E2Eテストが通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)