### PR TITLE
chore(rules): CLAUDE.md を分割し .claude/rules/ に集約

### DIFF
--- a/.claude/rules/commands.md
+++ b/.claude/rules/commands.md
@@ -1,0 +1,31 @@
+---
+description: Build & Dev コマンド（pnpm / Prisma）
+globs: 
+---
+
+# Build & Dev コマンド
+
+すべて `front/` ディレクトリで実行する。
+
+## 開発・ビルド
+
+```bash
+pnpm install   # 依存インストール
+pnpm dev       # 開発サーバー起動（http://localhost:3000）
+pnpm build     # プロダクションビルド
+pnpm start     # プロダクションビルド配信
+pnpm format    # Prettier 整形
+```
+
+## テスト
+
+テストコマンドは `.claude/rules/testing.md` を参照。
+
+## Prisma
+
+```bash
+pnpm prisma db pull       # 既存DBスキーマを取得（マイグレーションは禁止）
+pnpm prisma generate      # Prisma Client 再生成
+```
+
+- `prisma migrate` は禁止。詳細は `.claude/rules/database.md` を参照。

--- a/.claude/rules/environment.md
+++ b/.claude/rules/environment.md
@@ -1,0 +1,27 @@
+---
+description: 環境変数一覧・管理方針（クライアント/サーバー区分）
+globs: 
+---
+
+# 環境変数
+
+## 一覧
+
+| 変数 | スコープ | 用途 |
+|---|---|---|
+| `NEXT_PUBLIC_SUPABASE_URL` | クライアント | Supabase API URL |
+| `NEXT_PUBLIC_SUPABASE_ANON_KEY` | クライアント | Supabase anon key |
+| `NEXT_PUBLIC_SITE_URL` | クライアント | Google OAuth リダイレクト先 |
+| `ADMIN_EMAIL` | **サーバー専用** | 管理者メール（カンマ区切りで複数可）。`/api/auth/admin` で照合 |
+| `DATABASE_URL` | **サーバー専用** | Supabase Postgres 接続文字列（`prisma.config.ts` で参照） |
+
+## 管理方針
+
+- ローカル: `front/.env.local` に記載（`.gitignore` 対象）。
+- 本番: Vercel の環境変数で管理。
+- CI（テスト実行時）: `NEXT_PUBLIC_SUPABASE_URL` / `NEXT_PUBLIC_SUPABASE_ANON_KEY` はダミー値で動作させる。
+
+## 注意事項
+
+- `ADMIN_EMAIL` / `DATABASE_URL` には **`NEXT_PUBLIC_` プレフィックスを付けない**（クライアントバンドルに混入させない）。
+- シークレットをコードにハードコードしない。詳細は `.claude/rules/security.md` を参照。

--- a/.claude/rules/git-workflow.md
+++ b/.claude/rules/git-workflow.md
@@ -1,0 +1,28 @@
+---
+description: Git ワークフロー（ブランチ運用・コミットメッセージ・PR 規約）
+globs: 
+---
+
+# Git ワークフロー（コミット・ブランチ・PR）
+
+## ブランチ運用
+
+- 開発は必ずブランチを切って作業する。`main` への直接コミットは禁止。
+- ブランチ名は作業内容を表すケバブケース（例: `feat/report-filter`, `fix/auth-redirect`, `chore/update-deps`）。
+- Vercel は `main` ブランチのみ本番デプロイ（プレビュー無し）。
+
+## コミットメッセージ
+
+- 短い命令形（英語）で書く。
+  - Good: `Add report filter state`
+  - Good: `Fix admin email check`
+  - Bad: `修正しました` / `update`
+- 1コミット1論点。無関係な変更を混ぜない。
+
+## Pull Request
+
+- PR には以下を必ず含める:
+  - **概要**: 何を・なぜ変更したか
+  - **テストメモ**: 実行したテスト・確認手順
+  - **スクリーンショット**: UI 変更時は必須（before/after があると良い）
+- マージ前に CI（ビルド・テスト・lint）がグリーンであること。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,46 +25,9 @@ Markdownレポートの保存・閲覧UIを提供するNext.jsアプリ。
 - E2E: Playwright
 - Deploy: Vercel (`main` ブランチのみ本番デプロイ、プレビュー無し)
 
-## Build & Dev Commands
-すべて `front/` ディレクトリで実行:
-```
-pnpm install         # 依存インストール
-pnpm dev             # 開発サーバー起動
-pnpm build           # プロダクションビルド
-pnpm start           # プロダクションビルド配信
-pnpm format          # Prettier整形
-```
-
-## Testing
-```
-cd front
-pnpm test                    # ユニットテスト実行
-pnpm test:watch              # ウォッチモード
-pnpm exec playwright install # 初回のみ
-pnpm test:e2e                # E2Eテスト実行
-pnpm test:e2e:ui             # UIモード
-pnpm test:e2e:report         # レポート表示
-```
-- テスト設計: `docs/test-design/` / テスト仕様: `docs/spec/04.e2e-cases.md`
-- CI では `NEXT_PUBLIC_SUPABASE_URL` / `NEXT_PUBLIC_SUPABASE_ANON_KEY` にダミー値を使用
-- 詳細方針は `.claude/rules/testing.md` を参照
-
-## Commit & Branch Rules
-- 開発は必ずブランチを切って作業する（`main` 直接作業禁止）
-- コミットメッセージは短い命令形（例: "Add report filter state"）
-- PRには概要・テストメモ・UI変更時はスクリーンショットを含める
-
-## Environment Variables
-- `NEXT_PUBLIC_SUPABASE_URL` — Supabase API URL
-- `NEXT_PUBLIC_SUPABASE_ANON_KEY` — Supabase anon key
-- `NEXT_PUBLIC_SITE_URL` — Google OAuthリダイレクト用
-- `ADMIN_EMAIL` — 管理者メール（サーバーサイドAPI経由で制御、カンマ区切りで複数指定可）
-- `DATABASE_URL` — Supabase Postgres接続（`prisma.config.ts` で参照）
-
 ## Key Design Decisions
 - ローカルモード（localStorage）はE2E専用。本番はSupabaseデータのみ表示
 - カテゴリは固定リスト: Development / AI / Cloud / Linux / Container / Application / Program / Hobby
-- セキュリティ・DB詳細は `.claude/rules/security.md` / `.claude/rules/database.md` を参照
 
 ## Task Management
 - タスク一覧は `docs/TASKS.md` で管理
@@ -78,9 +41,12 @@ pnpm test:e2e:report         # レポート表示
 | ファイル | スコープ | 内容 |
 |---|---|---|
 | `coding-standards.md` | 全体 | コーディング規約（TypeScript/pnpm/ESLint/Prettier） |
+| `commands.md` | 全体 | Build & Dev コマンド（pnpm dev / build / format 等） |
+| `environment.md` | 全体 | 環境変数一覧・管理方針 |
 | `error-handling.md` | 全体 | エラーハンドリング方針（バリデーション・ログ・HTTPステータス） |
+| `git-workflow.md` | 全体 | ブランチ・コミット・PR 規約 |
 | `security.md` | 全体 | セキュリティ設計方針（認証・RLS・XSS対策・シークレット管理） |
-| `testing.md` | 全体 | テスト方針・配置規約（Vitest + Playwright） |
+| `testing.md` | 全体 | テスト方針・コマンド・配置規約（Vitest + Playwright） |
 | `frontend.md` | `front/src/components/**`, `front/src/app/**`, `front/src/hooks/**` | Next.js App Router フロントエンド設計・アトミックデザイン規約 |
 | `api.md` | `front/src/app/api/**` | Next.js BFF（Route Handlers）設計・API ルール |
 | `database.md` | `front/prisma/**`, `front/src/lib/db.ts`, `front/src/app/api/**` | Prisma ORM 規約・マイグレーション禁止・RLSポリシー |


### PR DESCRIPTION
## Summary
- `.claude/rules/` に `commands.md`（Build & Dev コマンド）、`environment.md`（環境変数）、`git-workflow.md`（ブランチ/コミット/PR 規約）を新設
- CLAUDE.md から該当セクションを削除し、87 行 → 52 行へスリム化（常時ロードコンテキストを削減）
- 新規 3 ファイルは既存ルールと同じ `description` + `globs` の frontmatter 形式に統一し、CLAUDE.md の Rules テーブルも更新

## Test plan
- [ ] CLAUDE.md の Rules テーブルが新規 3 ファイル（commands / environment / git-workflow）を含むこと
- [ ] `.claude/rules/*.md` 全 10 ファイルが `description` + `globs` の frontmatter を持つこと
- [ ] CLAUDE.md から削除したコマンド・環境変数・git 規約の内容が `.claude/rules/` 側で参照できること

🤖 Generated with [Claude Code](https://claude.com/claude-code)