### PR TITLE
fix(vercel): 本番デプロイが ignoreCommand でスキップされる問題を修正

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,3 +1,3 @@
 {
-  "ignoreCommand": "git diff HEAD^ HEAD --quiet -- front/"
+  "ignoreCommand": "test -n \"$VERCEL_GIT_PREVIOUS_SHA\" && git diff --quiet \"$VERCEL_GIT_PREVIOUS_SHA\" \"$VERCEL_GIT_COMMIT_SHA\" -- front/"
 }


### PR DESCRIPTION
Closes #68

## 概要

`front/` を変更した PR をマージしても本番に反映されない問題を修正する。原因は `vercel.json` の `ignoreCommand` がマージcommitで誤判定し、本番ビルドが CANCELED されていたこと。

## 原因

```json
{ "ignoreCommand": "git diff HEAD^ HEAD --quiet -- front/" }
```

Vercel のシャロークローン環境では、マージcommit に対する `HEAD^` が第2親（feature 先端）側として評価される。マージcommit と feature 先端は `front/` の中身が同一なため差分ゼロ → `exit 0`（変更なし）と判定され、`front/` を変更した PR でもビルドがスキップ（CANCELED）されていた。

## 変更

```json
{ "ignoreCommand": "test -n \"$VERCEL_GIT_PREVIOUS_SHA\" && git diff --quiet \"$VERCEL_GIT_PREVIOUS_SHA\" \"$VERCEL_GIT_COMMIT_SHA\" -- front/" }
```

- `HEAD^` をやめ、Vercel 提供の明示SHA（前回デプロイSHA / 今回commit SHA）で比較
- 前回SHAが空（初回デプロイ等）の場合は `test -n` で短絡し、安全側（ビルド実行）に倒す
- git エラー時も非ゼロ終了＝ビルド実行となり、デプロイ取りこぼしが起きない

## 効果

- マージcommitでも `front/` 変更を正しく検知してビルドされる
- **本 PR のマージで、未反映だった #67（フォント・callout 等のスタイル変更）も同時に本番反映される見込み**

## テストメモ

- ローカル再現:
  - `git diff --quiet 5d6948d^ 5d6948d -- front/` → exit 1（本来＝ビルドすべき）
  - `git diff --quiet 5d6948d^2 5d6948d -- front/` → exit 0（Vercel が見ていた側＝スキップ）
- マージ後、Vercel の本番デプロイが READY になり www.mdviewers.com に反映されることを確認する

## 確認してほしい点

- マージ後の本番デプロイが CANCELED ではなく READY になるか
- 反映後、レポート詳細画面でフォント・callout（まとめ/注意/トレンド）が表示されるか