### PR TITLE
chore(styles): 本番ビルドを発火して #67 のスタイルを反映

### DIFF
--- a/front/src/app/globals.css
+++ b/front/src/app/globals.css
@@ -1,3 +1,4 @@
+/* Report Viewer global styles (Markdown readability: Noto Sans JP headings + callouts) */
 @import "tailwindcss";
 
 :root {


### PR DESCRIPTION
## 概要

#67（フォント・callout 等のスタイル改善）が本番（www.mdviewers.com）に反映されない問題の復旧用 PR。

## 背景

- #67 / #69 はマージ済みで、`main`（fa7f11f）のツリーには新コードが正しく入っている（確認済み: layout に Noto Sans JP、globals に callout、ReportMarkdown に splitSections）。
- しかし `fa7f11f` のフレッシュビルドが一度も成立せず（INITIALIZING で停止 → CANCELED）、本番 production は約24日前の古いビルド/キャッシュ（CSS `afd2475...`、フォント `playfair_display`）を配信し続けている。
- Redeploy は旧成果物を流用するため、このループから抜けられない。

## 対応

`front/src/app/globals.css` の先頭にヘッダコメント1行を追加し、`front/` に実体差分を作る。これにより `vercel.json` の ignoreCommand が「front/ 変更あり」と判定し、`main` から**新規フレッシュビルド**を発火させる。

```diff
+/* Report Viewer global styles (Markdown readability: Noto Sans JP headings + callouts) */
 @import "tailwindcss";
```

## 期待結果

- マージ後、production デプロイが READY になる
- www.mdviewers.com の body フォントが `noto_sans_jp` になり、レポート詳細で callout（まとめ/注意/トレンド）が表示される

## テストメモ

- ローカル `main`(fa7f11f) ツリー検証: layout に Noto_Sans_JP ×2 / globals に report-callout ×15 / ReportMarkdown に splitSections ×2 を確認済み
- 機能的変更なし（CSS コメント追加のみ）