### PR TITLE
fix(vercel): ignoreCommand を撤去して本番デプロイのスキップを解消

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,3 +1,1 @@
-{
-  "ignoreCommand": "test -n \"$VERCEL_GIT_PREVIOUS_SHA\" && git diff --quiet \"$VERCEL_GIT_PREVIOUS_SHA\" \"$VERCEL_GIT_COMMIT_SHA\" -- front/"
-}
+{}


### PR DESCRIPTION
Closes #71

## 概要

`front/` を変更した PR をマージしても本番に反映されない問題の**根本対応**。`vercel.json` の `ignoreCommand` を撤去する。

## 根本原因（ビルドログで確定）

PR #70 マージ commit `616a410` の本番デプロイ build ログ:

```
Cloning ... (Branch: main, Commit: 616a410)
Running "test -n "$VERCEL_GIT_PREVIOUS_SHA" && git diff --quiet ... -- front/"
→ The Deployment has been canceled as a result of running the command defined in the "Ignored Build Step" setting.
```

- `ignoreCommand` は exit 0=スキップ / 非0=ビルド。
- Vercel のシャロークローン環境では `HEAD^` も `$VERCEL_GIT_PREVIOUS_SHA` も**手元に存在しない SHA** のため、`git diff` が front/ 差分を検出できず exit 0（スキップ）を返していた。
- `HEAD^ 方式`（#64〜）も `明示SHA方式`（#69）も同じ理由で機能せず、production は約24日前の旧ビルドを配信し続けていた。

## 変更

```diff
-{
-  "ignoreCommand": "test -n \"$VERCEL_GIT_PREVIOUS_SHA\" && git diff --quiet \"$VERCEL_GIT_PREVIOUS_SHA\" \"$VERCEL_GIT_COMMIT_SHA\" -- front/"
-}
+{}
```

- git 祖先比較に依存する判定を廃止。main への push は常に本番ビルドされる。
- `front/` のみをデプロイ対象とする要件は、プロジェクト設定の Root Directory（`front/`）で担保済み。

## 効果

- **本 PR のマージで production ビルドが実行され、未反映だった #67（フォント・callout）も本番反映される見込み。**

## テストメモ

- マージ後、production デプロイが READY になり、www.mdviewers.com の body フォントが `noto_sans_jp`・CSS ハッシュが更新され、callout が表示されることを確認する。

## 補足

将来 docs 等のみの変更でビルドを省略したくなった場合は、git diff に依存しない方式（Vercel ダッシュボードの Ignored Build Step）で別途検討する。