### PR TITLE
docs: restructure front/README and dedupe with root README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,75 +22,20 @@ ChatGPT / Gemini / Perplexity などで生成した **Markdown レポートを S
 
 ## 技術スタック
 
-| 領域 | 採用技術 |
-|---|---|
-| 言語 | TypeScript 5（strict） |
-| フレームワーク | Next.js 16（App Router） / React 19 |
-| スタイリング | TailwindCSS v4 |
-| Markdown | react-markdown 10 + remark-gfm 4 + rehype-sanitize 6 |
-| 認証 | Supabase Auth（Google OAuth） |
-| DB | Supabase Postgres（RLS） |
-| ORM | Prisma 6（`db pull` のみ・マイグレーション禁止） |
-| BFF | Next.js Route Handlers（`/api/*`） |
-| テスト | Vitest（ユニット） + Playwright（E2E） |
-| デプロイ | Vercel（`main` のみ本番、プレビュー無し） |
-| パッケージマネージャ | **pnpm**（npm / yarn は使用しない） |
+TypeScript + Next.js 16（App Router）/ React 19 + TailwindCSS v4 を中核に、Supabase（Auth + Postgres/RLS）+ Prisma（BFF は Next.js Route Handlers）で構成。テストは Vitest + Playwright、デプロイは Vercel（`main` のみ本番）。パッケージマネージャは **pnpm**。
+
+> 版数を含む一覧は [front/README.md](front/README.md#技術スタック)、選定理由は [docs/09-architecture-specification.md](docs/09-architecture-specification.md) を参照。
 
 ## 画面 / ルート
 
 - ルーティング一覧（認証要件含む）: [docs/03-functional-specification.md](docs/03-functional-specification.md)
 - 画面遷移: [docs/03-functional-specification.md](docs/03-functional-specification.md)
 
-## 必要要件
+## セットアップ・開発
 
-- Node.js 20+ / pnpm 9+（`npm i -g pnpm` で導入）
-- （本番データを扱う場合）Supabase プロジェクト + Google OAuth クライアント
+必要要件・セットアップ・起動（local / supabase モード）・本番セットアップ・ビルド・テストの手順は、実装ディレクトリの **[front/README.md](front/README.md)** に集約しています。
 
-## クイックスタート（まずは local モードで動かす）
-
-Supabase を用意しなくても、E2E 用の **local モード**（localStorage のダミーデータ）で UI を確認できます。最短で動かすならこちら。
-
-```bash
-cd front
-pnpm install
-NEXT_PUBLIC_AUTH_MODE=local NEXT_PUBLIC_DATA_MODE=local pnpm dev
-# http://localhost:3000
-```
-
-> 通常の `pnpm dev` は **supabase モード**で起動し、`.env.local`（後述）が無いとデータを取得できません。初見はまず local モードを推奨します。
-
-## 環境変数
-
-`front/.env.local` に設定します（テンプレートは `front/.env.local.example`）。
-
-- 変数一覧: [docs/04-non-functional-specification.md](docs/04-non-functional-specification.md)
-- 補足: `ADMIN_EMAIL`（管理者ログイン）と `DATABASE_URL`（API/DB書き込み）が無いと、本番モードで投稿・編集・削除は動きません。
-
-## 本番セットアップ（supabase モード）
-
-1. **Supabase プロジェクト作成** — `Report` / `ReportTag` / `ReportTagMapping` / `ExternalUrl` テーブルと RLS を用意（スキーマは [docs/05-data-specification.md](docs/05-data-specification.md)）。DBスキーマ変更は別プロジェクトで管理し、本リポジトリは `pnpm prisma db pull` で取り込むのみ。
-2. **Google OAuth** — Supabase Auth に Google プロバイダを設定し、リダイレクトに `NEXT_PUBLIC_SITE_URL` を使用。
-3. **環境変数** — 上表のキーを `front/.env.local` に設定（`front/.env.local.example` をコピー）。
-4. **起動** — `cd front && pnpm install && pnpm dev`。
-
-## ビルド
-
-```bash
-cd front
-pnpm build
-pnpm start
-```
-
-## テスト
-
-```bash
-cd front
-pnpm test                  # ユニット（Vitest）
-pnpm exec playwright install   # 初回のみ
-pnpm test:e2e              # E2E（Playwright）
-```
-
-E2E は `NEXT_PUBLIC_AUTH_MODE=local` / `NEXT_PUBLIC_DATA_MODE=local` 前提で動作します（`front/playwright.config.ts` が注入）。
+> 最短で UI を確認するなら local モード: `cd front && pnpm install && NEXT_PUBLIC_AUTH_MODE=local NEXT_PUBLIC_DATA_MODE=local pnpm dev`（詳細は [front/README.md](front/README.md)）。
 
 ## ディレクトリ構成
 

--- a/front/README.md
+++ b/front/README.md
@@ -1,49 +1,188 @@
-# Frontend (Next.js)
+# front — Report Viewer (Next.js App Router)
 
-`front/` is the active Next.js App Router implementation for the Report Viewer UI.
-Use **pnpm** (npm / yarn are not used in this project).
+Markdown レポートの保存・閲覧 UI の**実装ディレクトリ**です。すべての開発はここで行います（`base/` は参照専用・変更禁止）。
 
-## Setup
+> プロジェクト全体像・主な機能・本番セットアップは リポジトリ直下の [../README.md](../README.md) を参照。本書は `front/` 内で開発する人向けの作業手引きです。
+
+## 目次
+
+- [技術スタック](#技術スタック)
+- [ディレクトリ構成](#ディレクトリ構成)
+- [必要要件](#必要要件)
+- [環境構築](#環境構築)
+- [クイックスタート](#クイックスタート)
+- [動作モード（local / supabase）](#動作モードlocal--supabase)
+- [本番セットアップ（supabase モード）](#本番セットアップsupabase-モード)
+- [静的解析・フォーマット](#静的解析フォーマット)
+- [テスト](#テスト)
+- [Prisma / DB スキーマ](#prisma--db-スキーマ)
+- [注意点](#注意点)
+- [ドキュメント](#ドキュメント)
+
+## 技術スタック
+
+| 領域 | 採用技術 |
+|---|---|
+| 言語 | TypeScript 5（strict） |
+| フレームワーク | Next.js 16（App Router） / React 19 |
+| スタイリング | TailwindCSS v4 |
+| Markdown | react-markdown 10 + remark-gfm 4 + rehype-sanitize 6 |
+| 認証 | Supabase Auth（Google OAuth） |
+| DB / ORM | Supabase Postgres（RLS） / Prisma 6（`db pull` のみ・マイグレーション禁止） |
+| BFF | Next.js Route Handlers（`src/app/api/*`） |
+| テスト | Vitest（ユニット） + Playwright（E2E） |
+| 静的解析 | ESLint 9 + Prettier 3 |
+| パッケージマネージャ | **pnpm**（npm / yarn は使用しない） |
+
+詳細な技術選定理由は [../docs/09-architecture-specification.md](../docs/09-architecture-specification.md) を参照。
+
+## ディレクトリ構成
+
 ```
+front/
+├── src/
+│   ├── app/                     App Router のルート
+│   │   ├── page.tsx             /            一覧
+│   │   ├── login/               /login       ログイン
+│   │   ├── report/[id]/         /report/:id  詳細・編集（page.tsx + client.tsx）
+│   │   ├── report/new/          /report/new  新規作成
+│   │   ├── report/markdown-lab/ 表示デザイン検証ページ（認証必須）
+│   │   └── api/                 BFF（Route Handlers）
+│   │       ├── auth/{admin,is-allowed}/   管理者・許可メール判定
+│   │       ├── reports/[id]/               一覧/詳細/作成/更新/削除
+│   │       └── tags/                       タグ一覧
+│   ├── components/              アトミックデザイン（atoms / molecules / organisms / pages）
+│   ├── hooks/                   クライアントロジック（カスタムフック）
+│   ├── lib/                     db / auth-server / supabaseClient / validation
+│   ├── providers/              アプリ全体の Context Provider
+│   ├── constants.tsx           テーマ・初期データ
+│   └── types.ts                型定義
+├── prisma/                     schema.prisma（db pull で取得）
+├── tests/e2e/                  Playwright E2E（app.spec.ts / helpers.ts）
+├── public/                     静的アセット
+└── 設定: next.config.ts / playwright.config.ts / vitest.config.ts /
+         eslint.config.mjs / prisma.config.ts / tsconfig.json
+```
+
+設計方針（サーバー/クライアント分離・アトミックデザイン）は [../.claude/rules/frontend.md](../.claude/rules/frontend.md) を参照。
+
+## 必要要件
+
+- Node.js 20+ / pnpm 9+（`npm i -g pnpm` で導入）
+- （本番データを扱う場合のみ）Supabase プロジェクト + Google OAuth クライアント
+
+## 環境構築
+
+```bash
+cd front
+pnpm install   # postinstall で prisma generate が自動実行される
+```
+
+環境変数は `front/.env.local` に設定します（`.gitignore` 対象）。テンプレートの `front/.env.local.example` をコピーして埋めてください。変数一覧は [../.claude/rules/environment.md](../.claude/rules/environment.md) を参照。
+
+```bash
+cp .env.local.example .env.local
+```
+
+
+- `NEXT_PUBLIC_SUPABASE_URL` / `NEXT_PUBLIC_SUPABASE_ANON_KEY` — Supabase クライアント
+- `NEXT_PUBLIC_SITE_URL` — Google OAuth リダイレクト先
+- `ADMIN_EMAIL`（**サーバー専用**） — 管理者メール許可リスト（カンマ区切り）
+- `DATABASE_URL`（**サーバー専用**） — Prisma / Supabase Postgres 接続文字列
+- `NEXT_PUBLIC_AUTH_MODE` / `NEXT_PUBLIC_DATA_MODE`（**E2E専用**） — `local` でローカルモードに切替
+
+> `ADMIN_EMAIL` / `DATABASE_URL` に `NEXT_PUBLIC_` を付けないこと（クライアントバンドルに混入する）。
+
+## クイックスタート
+
+Supabase を用意しなくても、**local モード**（localStorage のダミーデータ）で UI を確認できます。最短はこちら。
+
+```bash
+cd front
 pnpm install
-```
-
-## Development
-```
-pnpm dev
-```
-
-To run without Supabase (local/E2E data mode):
-```
 NEXT_PUBLIC_AUTH_MODE=local NEXT_PUBLIC_DATA_MODE=local pnpm dev
+# http://localhost:3000
 ```
 
-## Production build
-```
-pnpm build
-pnpm start
+通常起動（**supabase モード** / `.env.local` が必要）:
+
+```bash
+pnpm dev      # 開発サーバー
+pnpm build    # 本番ビルド
+pnpm start    # ビルド成果物を配信
 ```
 
-## E2E (Playwright)
-```
-pnpm exec playwright install
-pnpm test:e2e
+## 動作モード（local / supabase）
+
+このアプリは認証・データ取得をそれぞれ2モードで切り替えます。環境変数 `NEXT_PUBLIC_AUTH_MODE` / `NEXT_PUBLIC_DATA_MODE` で制御し、**未設定なら supabase モード**になります。
+
+| | local モード（`=local`） | supabase モード（既定） |
+|---|---|---|
+| 認証（`NEXT_PUBLIC_AUTH_MODE`） | ダミー認証。`ADMIN_EMAIL` 不要 | Supabase Auth（Google OAuth）+ `ADMIN_EMAIL` 照合 |
+| データ（`NEXT_PUBLIC_DATA_MODE`） | localStorage のダミーデータ | Supabase Postgres（Prisma 経由） |
+| 用途 | E2E / UI 確認（`.env.local` 不要） | 開発・本番 |
+
+- 本番は **supabase モードのみ**。local モードは E2E 専用で、本番データは表示しません。
+- E2E 実行時は `playwright.config.ts` が両変数に `local` を注入します（手動設定は不要）。
+
+## 本番セットアップ（supabase モード）
+
+本番データを扱う場合の初期セットアップ。DB スキーマ変更は本リポジトリで行わず、別プロジェクトで管理する。
+
+1. **Supabase プロジェクト作成** — `Report` / `ReportTag` / `ReportTagMapping` / `ExternalUrl` テーブルと RLS を用意（スキーマは [../docs/05-data-specification.md](../docs/05-data-specification.md)）。本リポジトリは `pnpm prisma db pull` で取り込むのみ。
+2. **Google OAuth** — Supabase Auth に Google プロバイダを設定し、リダイレクトに `NEXT_PUBLIC_SITE_URL` を使用。
+3. **環境変数** — `front/.env.local` に各キーを設定（`.env.local.example` をコピー）。
+4. **起動** — `pnpm install && pnpm dev`。
+
+## 静的解析・フォーマット
+
+```bash
+pnpm lint     # ESLint（CI のグリーン条件）
+pnpm format   # Prettier 整形（--write）
 ```
 
-## Unit tests (Vitest)
+- TypeScript strict / 2スペース / セミコロンあり。規約は [../.claude/rules/coding-standards.md](../.claude/rules/coding-standards.md)。
+- インポートは `@/*` パスエイリアスを使用する。
+
+## テスト
+
+正常 / 準正常 / 異常をユニット・E2E の両方で必須にしています（[../.claude/rules/testing.md](../.claude/rules/testing.md)）。
+
+```bash
+pnpm test            # ユニット（Vitest） — src/<module>/__tests__/ に配置
+pnpm test:watch      # ユニット（watch）
+pnpm exec playwright install   # E2E 初回のみ
+pnpm test:e2e        # E2E（Playwright） — tests/e2e/ に配置
+pnpm test:e2e:ui     # E2E（UIモード）
+pnpm test:e2e:report # 直近の E2E レポート表示
 ```
-pnpm test
+
+E2E は `NEXT_PUBLIC_AUTH_MODE=local` / `NEXT_PUBLIC_DATA_MODE=local` 前提で動作します（`playwright.config.ts` が注入）。テストケース設計は [../docs/08-test-specification.md](../docs/08-test-specification.md)。
+
+## Prisma / DB スキーマ
+
+```bash
+pnpm prisma db pull   # 既存 DB スキーマを schema.prisma に取り込む
+pnpm prisma generate  # Prisma Client を再生成（pnpm install の postinstall でも自動実行）
 ```
 
-## Environment variables
-Copy `.env.local.example` to `.env.local` and fill in real values.
+- **`prisma migrate` は禁止**。スキーマ変更は DB 側（別プロジェクト）で行い、本リポジトリは `db pull` で取り込むのみ。
+- 接続文字列は `DATABASE_URL`（サーバー専用）。スキーマ・RLS は [../docs/05-data-specification.md](../docs/05-data-specification.md)、ORM 規約は [../.claude/rules/database.md](../.claude/rules/database.md) を参照。
 
-- `NEXT_PUBLIC_SUPABASE_URL`
-- `NEXT_PUBLIC_SUPABASE_ANON_KEY`
-- `NEXT_PUBLIC_SITE_URL` (OAuth redirect)
-- `ADMIN_EMAIL` (server-only; comma-separated admin allowlist)
-- `DATABASE_URL` (server-only; Prisma / Supabase Postgres connection)
-- `NEXT_PUBLIC_AUTH_MODE` / `NEXT_PUBLIC_DATA_MODE` (local mode for E2E)
+## 注意点
 
-## Docs
-See `../README.md` for setup and `../docs/README.md` for requirements, UI, data, API, and E2E specs.
+- 実装は `front/` のみ。`base/`（旧 Vite 実装の凍結スナップショット）は変更禁止。
+- **Prisma マイグレーション禁止**。スキーマ変更は `pnpm prisma db pull` で取り込むのみ（DB 側は別プロジェクトで管理）。[../.claude/rules/database.md](../.claude/rules/database.md)
+- local モードは E2E 専用。本番は Supabase データのみ表示する。
+- Markdown 表示は `rehype-sanitize` で必ずサニタイズ（生 HTML 挿入禁止）。[../.claude/rules/security.md](../.claude/rules/security.md)
+- `main` への直接コミット禁止（必ずブランチを切る）。Vercel は `main` のみ本番デプロイ（プレビュー無し）。[../.claude/rules/git-workflow.md](../.claude/rules/git-workflow.md)
+- コード変更時は影響するドキュメントを同一 PR で更新する。[../.claude/rules/documentation.md](../.claude/rules/documentation.md)
+
+## ドキュメント
+
+- [../docs/README.md](../docs/README.md) — 仕様書の索引と読む順序
+- [../docs/03-functional-specification.md](../docs/03-functional-specification.md) — 画面・ルーティング・外部URL
+- [../docs/07-api-specification.md](../docs/07-api-specification.md) — Route Handlers / API
+- [../docs/09-architecture-specification.md](../docs/09-architecture-specification.md) — アーキテクチャ・技術スタック
+- [../docs/11-tasks.md](../docs/11-tasks.md) — タスク一覧（作業前後で確認・更新）
+- 実装/設計ルール: [../.claude/rules/](../.claude/rules/)


### PR DESCRIPTION
## 概要
README を整理し、`front/README.md` を開発者向けの正準ドキュメントに位置づけ、root `README.md` との重複（特にバージョン乖離の源）を解消した。

## Summary
- **front/README.md（正準化）**: 動作モード（local/supabase）・本番セットアップ・Prisma/DB スキーマのセクションを追加。版数入りの技術スタック表を保持。
- **README.md（root・製品入口化）**: 必要要件・クイックスタート・環境変数・本番セットアップ・ビルド・テストの手順を front/README.md への参照に集約。技術スタック表は散文サマリ + docs/09 / front リンクに簡素化。
- 役割分担を「事実リスト（版数・変数・手順）は front 1か所、root は製品概要 + 参照」に統一。

## テストメモ
- ドキュメントのみの変更（コード変更なし）。
- [ ] root / front の README が GitHub 上で正しくレンダリングされること（目次アンカー・相対リンク含む）
- [ ] `front/README.md` 内の docs/ 相対リンク（`../docs/...`、`../.claude/rules/...`）が有効なこと
- [ ] root `README.md` から `front/README.md#技術スタック` へのアンカーリンクが機能すること

## ドキュメント乖離チェック
- `.claude/rules/documentation.md` の影響マップ上、本変更（README 整理）に対応する更新必須ドキュメントは無いためスキップ。コード・仕様の変更は含まない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)