### PR TITLE
ci: 静的解析ジョブ（ESLint + tsc）を CI に追加

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,37 @@ permissions:
   contents: read
 
 jobs:
+  static-analysis:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: front
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "pnpm"
+          cache-dependency-path: front/pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Lint (ESLint)
+        run: pnpm lint
+
+      - name: Type check (tsc)
+        run: pnpm typecheck
+
   playwright:
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/docs/04-non-functional-specification.md
+++ b/docs/04-non-functional-specification.md
@@ -13,7 +13,7 @@
 
 - デプロイ: 本番運用はVercelで実施（デプロイ必須）。
 - CI/CD: 自動デプロイのみ（Vercel連携を前提）。`main` ブランチのみ本番デプロイ。プレビューは不要。
-- CI: GitHub ActionsでユニットテストとE2E（Playwright）を自動実行する。
+- CI: GitHub Actions（`.github/workflows/test.yml`）で自動実行する。`static-analysis` ジョブが静的解析（ESLint `pnpm lint` + 型チェック `pnpm typecheck`）、`playwright` ジョブがユニット（Vitest）+ E2E（Playwright）を担当し、並列実行する。
 - テスト: 正常/準正常/異常をすべて必須とする（ユニット + E2E）。詳細は `docs/08-test-specification.md`。
 - 監視/ログ: 不具合を早期発見できるログ設計を意識する。
 - セキュリティ: Markdown表示はサニタイズ必須。Supabase RLSは「公開閲覧 + 認証ユーザーのみ書き込み」を採用する（詳細: `docs/06-security-specification.md`）。

--- a/front/package.json
+++ b/front/package.json
@@ -8,6 +8,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
+    "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:e2e": "playwright test",


### PR DESCRIPTION
## 概要
CI（`.github/workflows/test.yml`）に **静的解析ジョブ `static-analysis`** を追加する。`playwright` ジョブと並列で実行する。

これまで lint / 型チェックはローカル実行のみで、CI のゲートに無かった（実際、直近の作業で main 上に既存の lint エラー・型エラーが存在していたことが判明済み）。本変更でそれらを CI で検知できるようにする。

## 変更
- `static-analysis` ジョブ追加: `pnpm lint`（ESLint）+ `pnpm typecheck`（`tsc --noEmit`）。Playwright ブラウザは不要なので軽量・高速。
- `front/package.json` に `typecheck` スクリプト追加。
- `docs/04-non-functional-specification.md` の CI 記述を更新（影響マップ準拠）。

## ジョブ構成（並列）
| ジョブ | 内容 |
|---|---|
| `static-analysis` | ESLint + tsc |
| `playwright` | Vitest（ユニット）+ Playwright（E2E） |

## テストメモ
- ローカルで `pnpm lint` / `pnpm typecheck` ともに PASS を確認。
- ワークフローは既存 `playwright` ジョブと同じ手順（pnpm/Node 20/frozen-lockfile）を踏襲。`run:` に外部入力は含めない（インジェクション無し）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)