### PR TITLE
docs(rules): add JSDoc/TSDoc documentation rule

### DIFF
--- a/.claude/rules/jsdoc.md
+++ b/.claude/rules/jsdoc.md
@@ -1,0 +1,59 @@
+---
+description: JSDoc（TSDoc）ドキュメンテーションコメント規約 — TypeScript の公開シンボルに必須
+globs: "front/src/**"
+---
+
+# JSDoc 規約（TypeScript）
+
+TypeScript コードの**公開シンボル**には JSDoc（TSDoc 記法）を**必須**とする。TypeDoc によるドキュメント生成を前提とする。
+
+## 必須対象（公開シンボル）
+
+以下の公開シンボルには JSDoc を必ず付与する:
+
+- `export` された関数・クラス・メソッド・型（`type` / `interface`）・定数
+- React/Vue コンポーネントの **props 型**（各プロパティに説明）
+- カスタムフック（`useXxx`）・composable（`useXxx`）
+- 公開 API のハンドラー・サービスメソッド
+
+**任意対象**: `export` されない内部関数、および処理が自明な 1 行ユーティリティ。ただし意図が非自明なものは内部でも付与する。
+
+## 混乱テスト（公開/内部・本番/テストを問わない）
+
+判断軸は「public か否か」ではなく **「1 か月後の自分／他プロジェクト帰りの読み手が『これは何？なぜ？』となるか」**。なるなら、内部関数でもテストコードでも "why" を残す。
+
+- **キャスト・回避策には "why" 必須**: `as unknown as` / `as any` / `@ts-ignore` / `@ts-expect-error` / マジック値 / 複雑な正規表現 / 明示的なワークアラウンド。**型を欺く・仕様を迂回する箇所は、その根拠（なぜ安全か／なぜ必要か）がコードから消える**ため、コメントが唯一の記録になる。
+  - 例: テストダブルを `repo as unknown as Repository<Task>` で注入する場合、「ダブルは対象が実際に呼ぶメソッドだけの部分実装で、実型は構造的に大きいため二段キャストで隙間を埋める（実行時は使う分だけで足りる）」と残す。
+- **テスト足場**（SUT ビルダー・複雑な fixture・非自明な mock）も、意図が読み取りにくいなら付ける。
+
+## 記述ルール
+
+- **型は書かない**: 型は TypeScript のシグネチャが唯一の真実（source of truth）。JSDoc に `{string}` 等の型ブレースを併記しない（二重管理・型ずれの原因になる）。JSDoc は**意図・意味・制約**を日本語で記述する。
+- **要約行必須**: 1 行目にそのシンボルが「何をするか」を簡潔に書く。
+- **`@param` 必須**: 全引数に `@param name - 説明` を記述する。オプション引数・デフォルト値の意味も明記する。
+- **`@returns` 必須**: 戻り値がある場合は `@returns 説明` を記述する（`void` / JSX 返却のコンポーネントは省略可）。
+- **`@throws` 必須**: 意図的に例外を投げる場合は `@throws {ErrorType} 発生条件` を記述する。
+- **補助タグ（任意）**: `@example` `@deprecated` `@see` は必要に応じて使う。
+
+## 例
+
+```ts
+/**
+ * ユーザー ID から表示名を解決する。キャッシュに無ければ API を叩く。
+ *
+ * @param userId - 対象ユーザーの UUID
+ * @param opts - 解決オプション（`force` 指定でキャッシュを無視）
+ * @returns 表示名。ユーザーが存在しない場合は `null`
+ * @throws {ApiError} API 通信に失敗した場合
+ */
+export async function resolveDisplayName(
+  userId: string,
+  opts?: { force?: boolean },
+): Promise<string | null> {
+  // ...
+}
+```
+
+## Lint による強制（推奨）
+
+`eslint-plugin-jsdoc` を導入し、公開シンボルへの JSDoc 欠落・`@param` / `@returns` 漏れを CI で検出する。TypeScript プロジェクトでは型ブレース系ルールを無効化する（`jsdoc/require-param-type` / `jsdoc/require-returns-type` を off）。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,3 +52,4 @@ Markdownレポートの保存・閲覧UIを提供するNext.jsアプリ。
 | `frontend.md` | `front/src/components/**`, `front/src/app/**`, `front/src/hooks/**` | Next.js App Router フロントエンド設計・アトミックデザイン規約 |
 | `api.md` | `front/src/app/api/**` | Next.js BFF（Route Handlers）設計・API ルール |
 | `database.md` | `front/prisma/**`, `front/src/lib/db.ts`, `front/src/app/api/**` | Prisma ORM 規約・マイグレーション禁止・RLSポリシー |
+| `jsdoc.md` | `front/src/**` | JSDoc（TSDoc）ドキュメンテーションコメント規約（公開シンボル必須・型は書かない・why 重視） |


### PR DESCRIPTION
## 概要

TypeScript の公開シンボルに対する JSDoc（TSDoc）規約を追加する。

- **何を**: `.claude/rules/jsdoc.md` を新規追加し、`CLAUDE.md` の Rules テーブルに1行登録
- **なぜ**: `/rules-update` スキルで TypeScript 系スタックを検出。既存 `.claude/rules/` にドキュメンテーションコメント規約が未整備だったため、公開シンボルの JSDoc 方針（型は書かない・why 重視・公開シンボル必須）を明文化する

### 変更点

- `.claude/rules/jsdoc.md` を追加（スコープ `front/src/**`。全 TS ソースが `front/src/` 配下に集約されているため単一 glob）
- `CLAUDE.md` の Rules テーブルに `jsdoc.md` 行を追加

> `/rules-update` が生成しうる他ファイル（coding-standards / error-handling / security / frontend / api / database / testing）は、**既存がプロジェクト固有で汎用テンプレートより詳細**なため意図的にスキップし、上書きしていない。

### ドキュメント影響マップ

`.claude/rules/` ルールの追加 → 更新必須は「`CLAUDE.md` の Rules テーブル」のみ（本 PR で同期済み）。他ドキュメントの更新は不要。

## テストメモ

- ドキュメント（ルール定義）のみの変更で、コード・ビルド・実行時挙動への影響なし
- `.gitignore` 違反 / シークレット混入 / 大容量ファイル（>1MB）: なし（コミット前スキャン済み）
- スコープ確認: `front/src/**`（既存 frontmatter 慣習 `description` + 引用符付き `globs` に一致）

## スクリーンショット

UI 変更なし（対象外）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)