### PR TITLE
chore(eslint): enforce JSDoc rules via eslint-plugin-jsdoc

### DIFF
--- a/.claude/rules/jsdoc.md
+++ b/.claude/rules/jsdoc.md
@@ -54,6 +54,13 @@ export async function resolveDisplayName(
 }
 ```
 
-## Lint による強制（推奨）
+## Lint による強制
 
-`eslint-plugin-jsdoc` を導入し、公開シンボルへの JSDoc 欠落・`@param` / `@returns` 漏れを CI で検出する。TypeScript プロジェクトでは型ブレース系ルールを無効化する（`jsdoc/require-param-type` / `jsdoc/require-returns-type` を off）。
+`eslint-plugin-jsdoc` を導入済み。**有効ルールの唯一の真実は `front/eslint.config.mjs` の JSDoc ブロック**（本書は方針、config は機械強制の実体）。CI の `static-analysis` ジョブ（`pnpm lint`）で検出する。
+
+方針:
+
+- **`require-jsdoc` は採用しない** — JSDoc の付与自体は強制せず、「書いたら完全であること」を強制する（未文書化の既存コードはエラーにせず段階導入する）。
+- `settings.jsdoc.mode = "typescript"` + `jsdoc/no-types` で型の再掲を禁止（型は TS シグネチャが唯一の真実）。
+- JSDoc ブロックを持つ関数は `jsdoc/require-param`（`checkDestructured: false`）/ `require-param-description` / `check-param-names` を必須。
+- 返り値のある関数は `jsdoc/require-returns` / `require-returns-description` を必須。ただし **JSX を返す `.tsx` は `require-returns` を off**（「@returns …の要素」はノイズのため）。`.ts` のフック / lib / API では必須のまま。

--- a/front/eslint.config.mjs
+++ b/front/eslint.config.mjs
@@ -1,10 +1,45 @@
 import { defineConfig, globalIgnores } from "eslint/config";
 import nextVitals from "eslint-config-next/core-web-vitals";
 import nextTs from "eslint-config-next/typescript";
+import jsdoc from "eslint-plugin-jsdoc";
 
 const eslintConfig = defineConfig([
   ...nextVitals,
   ...nextTs,
+  // JSDoc 規約（TSDoc スタイル）の機械的に判定できる部分を強制する。
+  // 有効ルールの唯一の真実はこのブロック。方針の根拠は .claude/rules/jsdoc.md。
+  // require-jsdoc は採用しない（JSDoc の付与は強制せず、書いたら完全であることを強制する）。
+  {
+    files: ["src/**/*.{ts,tsx}"],
+    plugins: { jsdoc },
+    // TS 前提。型は JSDoc ではなくシグネチャに委ねる。
+    settings: { jsdoc: { mode: "typescript" } },
+    rules: {
+      // 型の再掲を禁止（TS シグネチャが型の唯一の真実）。
+      "jsdoc/no-types": "error",
+      // JSDoc ブロックを持つ関数は全引数を @param で説明する。
+      // 分割代入 props は型（XxxProps）が真実なので props.x 単位には展開しない。
+      "jsdoc/require-param": ["error", { checkDestructured: false, checkDestructuredRoots: false }],
+      "jsdoc/require-param-description": "error",
+      // @param 名と実引数名を突き合わせる（名前ズレ・順序・過不足を検出）。
+      "jsdoc/check-param-names": "error",
+      // 返り値がある関数は @returns に意味を書く（.tsx コンポーネントは後続ブロックで除外）。
+      "jsdoc/require-returns": "error",
+      "jsdoc/require-returns-description": "error",
+      // 書いた JSDoc の体裁を整える。
+      "jsdoc/check-alignment": "warn",
+      "jsdoc/no-multi-asterisks": "warn",
+    },
+  },
+  {
+    // React コンポーネント（JSX を返す .tsx）は @returns を要求しない（「@returns …の要素」はノイズ）。
+    // .ts のフック / lib / API では @returns 必須のまま。
+    files: ["src/**/*.tsx"],
+    rules: {
+      "jsdoc/require-returns": "off",
+      "jsdoc/require-returns-description": "off",
+    },
+  },
   // Override default ignores of eslint-config-next.
   globalIgnores([
     // Default ignores of eslint-config-next:

--- a/front/package.json
+++ b/front/package.json
@@ -44,6 +44,7 @@
     "dotenv": "^17.2.2",
     "eslint": "^9",
     "eslint-config-next": "16.1.4",
+    "eslint-plugin-jsdoc": "^63.0.11",
     "happy-dom": "^20.8.9",
     "prettier": "^3.6.2",
     "prisma": "^6.19.2",

--- a/front/pnpm-lock.yaml
+++ b/front/pnpm-lock.yaml
@@ -81,6 +81,9 @@ importers:
       eslint-config-next:
         specifier: 16.1.4
         version: 16.1.4(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      eslint-plugin-jsdoc:
+        specifier: ^63.0.11
+        version: 63.0.11(eslint@9.39.2(jiti@2.6.1))
       happy-dom:
         specifier: ^20.8.9
         version: 20.8.9
@@ -195,6 +198,14 @@ packages:
 
   '@emnapi/wasi-threads@1.1.0':
     resolution: {integrity: sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==}
+
+  '@es-joy/jsdoccomment@0.88.0':
+    resolution: {integrity: sha512-GK/HL/claLLNo5KG705auIlZMwEtmn88ofSGuLsmVZwKBqMPJhW9DiznYNq07QEqz9BPtA3LBfYImtZmhVvRAw==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@es-joy/resolve.exports@1.2.0':
+    resolution: {integrity: sha512-Q9hjxWI5xBM+qW2enxfe8wDKdFWMfd0Z29k5ZJnuBqD/CasY5Zryj09aCA6owbGATWz+39p5uIdaHXpopOcG8g==}
+    engines: {node: '>=10'}
 
   '@esbuild/aix-ppc64@0.27.7':
     resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
@@ -987,6 +998,10 @@ packages:
   '@scarf/scarf@1.4.0':
     resolution: {integrity: sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==}
 
+  '@sindresorhus/base62@1.0.0':
+    resolution: {integrity: sha512-TeheYy0ILzBEI/CO55CP6zJCSdSWeRtGnHy8U8dWSUH4I68iqTsy7HkMktR4xakThc9jotkPQUXT4ITdbV7cHA==}
+    engines: {node: '>=18'}
+
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
@@ -1283,6 +1298,9 @@ packages:
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
 
@@ -1379,6 +1397,10 @@ packages:
 
   '@typescript-eslint/types@8.55.0':
     resolution: {integrity: sha512-ujT0Je8GI5BJWi+/mMoR0wxwVEQaxM+pi30xuMiJETlX80OPovb2p9E8ss87gnSVtYXtJoU9U1Cowcr6w2FE0w==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/types@8.62.1':
+    resolution: {integrity: sha512-ooCzJFaf+Hg+uG6fA3NRFGuFjlfNlDhBthbv4ZPU/0elCAFUfnyXUvf/WOpHz/jYwSmvU2GkR2LtyUfy1AxZ1Q==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@typescript-eslint/typescript-estree@8.55.0':
@@ -1543,6 +1565,11 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  acorn@8.17.0:
+    resolution: {integrity: sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
   agent-base@6.0.2:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
@@ -1564,6 +1591,10 @@ packages:
 
   apg-lite@1.0.5:
     resolution: {integrity: sha512-SlI+nLMQDzCZfS39ihzjGp3JNBQfJXyMi6cg9tkLOCPVErgFsUIAEdO9IezR7kbP5Xd0ozcPNQBkf9TO5cHgWw==}
+
+  are-docs-informative@0.0.2:
+    resolution: {integrity: sha512-ixiS0nLNNG5jNQzgZJNoUpBKdo9yTYZMGJ+QgT2jmjR7G7+QHRCc4v6LQ3NgE7EBJq+o0ams3waJwkrlBom8Ig==}
+    engines: {node: '>=14'}
 
   argparse@1.0.10:
     resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
@@ -1771,6 +1802,10 @@ packages:
 
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
+
+  comment-parser@1.4.7:
+    resolution: {integrity: sha512-0h+uSNtQGW3D98eQt3jJ8L06Fves8hncB4V/PKdw/Qb8Hnk19VaKuTr55UNRYiSoVa7WwrFls+rh3ux9agmkeQ==}
+    engines: {node: '>= 12.0.0'}
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
@@ -2047,6 +2082,12 @@ packages:
       '@typescript-eslint/parser':
         optional: true
 
+  eslint-plugin-jsdoc@63.0.11:
+    resolution: {integrity: sha512-QhLmqREgRJSIKg0r23ckTVaNK1lmMsTmpyY5Hv7NTCHNWTFZx/8PqycWhR0p0Lk/U5aJ6H3zAKMQ0xB2NkN0sA==}
+    engines: {node: ^22.13.0 || >=24}
+    peerDependencies:
+      eslint: ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0
+
   eslint-plugin-jsx-a11y@6.10.2:
     resolution: {integrity: sha512-scB3nz4WmG75pV8+3eRUQOHZlNSUhFNq37xnpgRkCCELU3XMvXAxLk1eqWWyE22Ki4Q01Fnsw9BA3cJHDPgn2Q==}
     engines: {node: '>=4.0'}
@@ -2077,6 +2118,10 @@ packages:
     resolution: {integrity: sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  eslint-visitor-keys@5.0.1:
+    resolution: {integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
   eslint@9.39.2:
     resolution: {integrity: sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -2090,6 +2135,10 @@ packages:
   espree@10.4.0:
     resolution: {integrity: sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  espree@11.2.0:
+    resolution: {integrity: sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
   esquery@1.7.0:
     resolution: {integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==}
@@ -2334,6 +2383,9 @@ packages:
   highlightjs-vue@1.0.0:
     resolution: {integrity: sha512-PDEfEF102G23vHmPhLyPboFCD+BkMGu+GuJe2d9/eH4FsCwvgBpnc9n0pGE+ffKdph38s6foEZiEjdgHdzp+IA==}
 
+  html-entities@2.6.0:
+    resolution: {integrity: sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==}
+
   html-url-attributes@3.0.1:
     resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
 
@@ -2530,6 +2582,10 @@ packages:
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
+
+  jsdoc-type-pratt-parser@7.2.0:
+    resolution: {integrity: sha512-dh140MMgjyg3JhJZY/+iEzW+NO5xR2gpbDFKHqotCmexElVntw7GjWjt511+C/Ef02RU5TKYrJo/Xlzk+OLaTw==}
+    engines: {node: '>=20.0.0'}
 
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
@@ -2923,6 +2979,9 @@ packages:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
 
+  object-deep-merge@2.0.1:
+    resolution: {integrity: sha512-aKttDKcU3pyZqKcCkDhsMn70WmZFG2JGDQLP9EcLyTSIFQRCPWLAmBZRLJnrVUrhPG1jETEEbfdgbNtJf1LyMg==}
+
   object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
     engines: {node: '>= 0.4'}
@@ -2984,6 +3043,12 @@ packages:
 
   parse-entities@4.0.2:
     resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
+
+  parse-imports-exports@0.2.4:
+    resolution: {integrity: sha512-4s6vd6dx1AotCx/RCI2m7t7GCh5bDRUtGNvRfHSP2wbBQdMi67pPe7mtzmgwcaQ8VKK/6IB7Glfyu3qdZJPybQ==}
+
+  parse-statements@1.0.11:
+    resolution: {integrity: sha512-HlsyYdMBnbPQ9Jr/VgJ1YF4scnldvJpJxCVx6KgqPL4dxppsWrJHCIIxQXMJrqGnsRkNPATbeMJ8Yxu7JMsYcA==}
 
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
@@ -3234,6 +3299,10 @@ packages:
   reselect@5.2.0:
     resolution: {integrity: sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==}
 
+  reserved-identifiers@1.2.0:
+    resolution: {integrity: sha512-yE7KUfFvaBFzGPs5H3Ops1RevfUEsDc5Iz65rOwWg4lE8HJSYtle77uul3+573457oHvBKuHYDl/xqUkKpEEdw==}
+    engines: {node: '>=18'}
+
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
@@ -3290,6 +3359,11 @@ packages:
 
   semver@7.7.4:
     resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  semver@7.8.5:
+    resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -3355,6 +3429,15 @@ packages:
 
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
+
+  spdx-exceptions@2.5.0:
+    resolution: {integrity: sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==}
+
+  spdx-expression-parse@4.0.0:
+    resolution: {integrity: sha512-Clya5JIij/7C6bRR22+tnGXbc4VKlibKSVj2iHvVeX5iMW7s1SIQlqu699JkODJJIhh/pUu8L0/VLh8xflD+LQ==}
+
+  spdx-license-ids@3.0.23:
+    resolution: {integrity: sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==}
 
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
@@ -3490,6 +3573,10 @@ packages:
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
+
+  to-valid-identifier@1.0.0:
+    resolution: {integrity: sha512-41wJyvKep3yT2tyPqX/4blcfybknGB4D+oETKLs7Q76UiPqRpUJK3hr1nxelyYO0PHKVzJwlu0aCeEAsGI6rpw==}
+    engines: {node: '>=20'}
 
   toggle-selection@1.0.6:
     resolution: {integrity: sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ==}
@@ -3913,6 +4000,16 @@ snapshots:
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@es-joy/jsdoccomment@0.88.0':
+    dependencies:
+      '@types/estree': 1.0.9
+      '@typescript-eslint/types': 8.62.1
+      comment-parser: 1.4.7
+      esquery: 1.7.0
+      jsdoc-type-pratt-parser: 7.2.0
+
+  '@es-joy/resolve.exports@1.2.0': {}
 
   '@esbuild/aix-ppc64@0.27.7':
     optional: true
@@ -4411,6 +4508,8 @@ snapshots:
   '@rtsao/scc@1.1.0': {}
 
   '@scarf/scarf@1.4.0': {}
+
+  '@sindresorhus/base62@1.0.0': {}
 
   '@standard-schema/spec@1.1.0': {}
 
@@ -5024,6 +5123,8 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
+  '@types/estree@1.0.9': {}
+
   '@types/hast@3.0.4':
     dependencies:
       '@types/unist': 3.0.3
@@ -5136,6 +5237,8 @@ snapshots:
       - supports-color
 
   '@typescript-eslint/types@8.55.0': {}
+
+  '@typescript-eslint/types@8.62.1': {}
 
   '@typescript-eslint/typescript-estree@8.55.0(typescript@5.9.3)':
     dependencies:
@@ -5275,7 +5378,13 @@ snapshots:
     dependencies:
       acorn: 8.15.0
 
+  acorn-jsx@5.3.2(acorn@8.17.0):
+    dependencies:
+      acorn: 8.17.0
+
   acorn@8.15.0: {}
+
+  acorn@8.17.0: {}
 
   agent-base@6.0.2:
     dependencies:
@@ -5299,6 +5408,8 @@ snapshots:
   ansi-styles@5.2.0: {}
 
   apg-lite@1.0.5: {}
+
+  are-docs-informative@0.0.2: {}
 
   argparse@1.0.10:
     dependencies:
@@ -5541,6 +5652,8 @@ snapshots:
       delayed-stream: 1.0.0
 
   comma-separated-tokens@2.0.3: {}
+
+  comment-parser@1.4.7: {}
 
   concat-map@0.0.1: {}
 
@@ -5926,6 +6039,26 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
+  eslint-plugin-jsdoc@63.0.11(eslint@9.39.2(jiti@2.6.1)):
+    dependencies:
+      '@es-joy/jsdoccomment': 0.88.0
+      '@es-joy/resolve.exports': 1.2.0
+      are-docs-informative: 0.0.2
+      comment-parser: 1.4.7
+      debug: 4.4.3
+      escape-string-regexp: 4.0.0
+      eslint: 9.39.2(jiti@2.6.1)
+      espree: 11.2.0
+      esquery: 1.7.0
+      html-entities: 2.6.0
+      object-deep-merge: 2.0.1
+      parse-imports-exports: 0.2.4
+      semver: 7.8.5
+      spdx-expression-parse: 4.0.0
+      to-valid-identifier: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
+
   eslint-plugin-jsx-a11y@6.10.2(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       aria-query: 5.3.2
@@ -5987,6 +6120,8 @@ snapshots:
 
   eslint-visitor-keys@4.2.1: {}
 
+  eslint-visitor-keys@5.0.1: {}
+
   eslint@9.39.2(jiti@2.6.1):
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.2(jiti@2.6.1))
@@ -6033,6 +6168,12 @@ snapshots:
       acorn: 8.15.0
       acorn-jsx: 5.3.2(acorn@8.15.0)
       eslint-visitor-keys: 4.2.1
+
+  espree@11.2.0:
+    dependencies:
+      acorn: 8.17.0
+      acorn-jsx: 5.3.2(acorn@8.17.0)
+      eslint-visitor-keys: 5.0.1
 
   esquery@1.7.0:
     dependencies:
@@ -6297,6 +6438,8 @@ snapshots:
 
   highlightjs-vue@1.0.0: {}
 
+  html-entities@2.6.0: {}
+
   html-url-attributes@3.0.1: {}
 
   https-proxy-agent@5.0.1:
@@ -6488,6 +6631,8 @@ snapshots:
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
+
+  jsdoc-type-pratt-parser@7.2.0: {}
 
   jsesc@3.1.0: {}
 
@@ -7044,6 +7189,8 @@ snapshots:
 
   object-assign@4.1.1: {}
 
+  object-deep-merge@2.0.1: {}
+
   object-inspect@1.13.4: {}
 
   object-keys@1.1.1: {}
@@ -7130,6 +7277,12 @@ snapshots:
       is-alphanumerical: 2.0.1
       is-decimal: 2.0.1
       is-hexadecimal: 2.0.1
+
+  parse-imports-exports@0.2.4:
+    dependencies:
+      parse-statements: 1.0.11
+
+  parse-statements@1.0.11: {}
 
   path-exists@4.0.0: {}
 
@@ -7401,6 +7554,8 @@ snapshots:
 
   reselect@5.2.0: {}
 
+  reserved-identifiers@1.2.0: {}
+
   resolve-from@4.0.0: {}
 
   resolve-pkg-maps@1.0.0: {}
@@ -7482,6 +7637,8 @@ snapshots:
   semver@6.3.1: {}
 
   semver@7.7.4: {}
+
+  semver@7.8.5: {}
 
   serialize-error@8.1.0:
     dependencies:
@@ -7588,6 +7745,15 @@ snapshots:
   source-map-js@1.2.1: {}
 
   space-separated-tokens@2.0.2: {}
+
+  spdx-exceptions@2.5.0: {}
+
+  spdx-expression-parse@4.0.0:
+    dependencies:
+      spdx-exceptions: 2.5.0
+      spdx-license-ids: 3.0.23
+
+  spdx-license-ids@3.0.23: {}
 
   sprintf-js@1.0.3: {}
 
@@ -7787,6 +7953,11 @@ snapshots:
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
+
+  to-valid-identifier@1.0.0:
+    dependencies:
+      '@sindresorhus/base62': 1.0.0
+      reserved-identifiers: 1.2.0
 
   toggle-selection@1.0.6: {}
 

--- a/front/src/app/api/openapi/route.ts
+++ b/front/src/app/api/openapi/route.ts
@@ -7,6 +7,9 @@ import pkg from '../../../../package.json';
  * OpenAPI ドキュメントを返す（管理者のみ）。
  * `/docs` の Swagger UI がこのエンドポイントを Bearer トークン付きで読み込む。
  * 契約は zod スキーマ（`lib/schemas/`）から生成され、`docs/openapi.json` と同一内容。
+ *
+ * @param request - 受信リクエスト（`requireAdmin` が Bearer トークンで管理者判定に使用）
+ * @returns 管理者なら OpenAPI ドキュメントの JSON、非管理者なら 401/403 レスポンス
  */
 export async function GET(request: NextRequest) {
   const auth = await requireAdmin(request, 'api/openapi');

--- a/front/src/components/organisms/ReportMarkdown.tsx
+++ b/front/src/components/organisms/ReportMarkdown.tsx
@@ -59,7 +59,11 @@ const classifyHeading = (heading: string): SectionKind => {
   return 'normal';
 };
 
-/** 本文を h2（## …）境界で分割し、各セクションを種類付きで返す。 */
+/**
+ * 本文を h2（## …）境界で分割し、各セクションを種類付きで返す。
+ *
+ * @param content - 分割対象の Markdown 本文
+ */
 const splitSections = (content: string): { kind: SectionKind; content: string }[] => {
   const lines = content.split('\n');
   const sections: { kind: SectionKind; lines: string[] }[] = [];

--- a/front/src/hooks/useLoginForm.ts
+++ b/front/src/hooks/useLoginForm.ts
@@ -5,7 +5,11 @@ interface UseLoginFormOptions {
   onLoginWithGoogle: () => Promise<string | null>;
 }
 
-/** URL の `?error=unauthorized` を初回レンダー時に解決する（SSR では window 不在のため null）。 */
+/**
+ * URL の `?error=unauthorized` を初回レンダー時に解決する（SSR では window 不在のため null）。
+ *
+ * @returns 未認可エラー時の日本語メッセージ、該当しなければ `null`
+ */
 const initialErrorFromUrl = (): string | null => {
   if (typeof window === 'undefined') return null;
   const errorParam = new URLSearchParams(window.location.search).get('error');

--- a/front/src/hooks/useReport.ts
+++ b/front/src/hooks/useReport.ts
@@ -5,6 +5,10 @@ import { ReportItem } from '@/types';
  * Fetches a single report with full content from /api/reports/[id].
  * Returns the cached report from the list (without content) immediately,
  * then replaces it with the full report once the API responds.
+ *
+ * @param reportId - 取得対象レポートの ID（未定義なら fetch しない）
+ * @param listReport - 一覧から渡る本文なしのキャッシュ。即時表示の初期値に使う
+ * @returns 現在のレポート（`report`）と取得中フラグ（`isLoading`）
  */
 export const useReport = (
   reportId: string | undefined,

--- a/front/src/lib/schemas/report.ts
+++ b/front/src/lib/schemas/report.ts
@@ -26,13 +26,21 @@ export const LIMITS = {
 
 const URL_PATTERN = /^https?:\/\//;
 
-/** 文字列以外は空文字に倒し、文字列はトリムする（既存 validation.ts と同一挙動）。 */
+/**
+ * 文字列以外は空文字に倒し、文字列はトリムする（既存 validation.ts と同一挙動）。
+ *
+ * @param value - 任意の入力値
+ * @returns トリム済み文字列。文字列でなければ空文字
+ */
 const toStringValue = (value: unknown): string => (typeof value === 'string' ? value.trim() : '');
 
 /**
  * タグの正規化。canonical form は `#` 付き。
  * - 配列入力: 各要素をトリムし、`#` が無ければ付与（非文字列要素は除外）
  * - 文字列入力: カンマ分割後、各要素をトリムし、`#` が無ければ付与
+ *
+ * @param value - タグの配列またはカンマ区切り文字列
+ * @returns `#` 付きに正規化したタグ配列（空要素は除外）
  */
 export const normalizeTags = (value: unknown): string[] => {
   const ensureHash = (tag: string) => {
@@ -53,7 +61,12 @@ export const normalizeTags = (value: unknown): string[] => {
   return [];
 };
 
-/** publishDate を Date | null | undefined に解釈する（不正値は undefined で無視）。 */
+/**
+ * publishDate を Date | null | undefined に解釈する（不正値は undefined で無視）。
+ *
+ * @param value - 日付候補（Date / 文字列 / null など）
+ * @returns 有効な `Date`、明示的な `null`、または不正・未指定時の `undefined`
+ */
 const parsePublishDate = (value: unknown): Date | null | undefined => {
   if (value === null) return null;
   if (value instanceof Date) return value;

--- a/front/src/lib/validation.ts
+++ b/front/src/lib/validation.ts
@@ -43,7 +43,12 @@ export { normalizeTags };
 const createReportSchema = reportCreateSchema.omit({ externalUrls: true });
 const patchReportSchema = reportPatchSchema.omit({ externalUrls: true });
 
-/** zod の issues を、先勝ちでフィールド名 → メッセージの平坦な形へ変換する。 */
+/**
+ * zod の issues を、先勝ちでフィールド名 → メッセージの平坦な形へ変換する。
+ *
+ * @param issues - zod のバリデーション issue 配列（`path` の先頭要素をフィールド名に使う）
+ * @returns フィールド名をキー、最初のエラーメッセージを値に持つオブジェクト
+ */
 const toFieldErrors = (issues: { path: PropertyKey[]; message: string }[]): ValidationErrors => {
   const errors: ValidationErrors = {};
   for (const issue of issues) {


### PR DESCRIPTION
## 概要

先の PR #79 で追加した JSDoc 規約（`.claude/rules/jsdoc.md`）を、ESLint で機械強制できるようにする。youtube-my-collection の設定を参考にした。

- **何を**: `front/eslint.config.mjs` に `eslint-plugin-jsdoc` の JSDoc ブロックを追加（スコープ `src/**/*.{ts,tsx}`）
- **なぜ**: jsdoc.md の「Lint による強制」を実体化し、書かれた JSDoc の不完全さ（`@param`/`@returns` 漏れ・型再掲・名前ズレ）を CI で検出するため

### 変更点

- `eslint-plugin-jsdoc@63.0.11` を devDependency に追加
- `eslint.config.mjs` に JSDoc ルールブロックを追加
  - `no-types` / `require-param(+description)` / `check-param-names` / `require-returns(+description)` / `check-alignment` / `no-multi-asterisks`
  - **`require-jsdoc` は不採用** → 未文書化の既存コードはエラーにせず段階導入
  - **JSX を返す `.tsx` は `require-returns` を off**（「@returns …の要素」はノイズのため）
- 新ルールで検出された**既存の不完全な JSDoc 6ファイルを補完**（`openapi/route.ts`, `ReportMarkdown.tsx`, `useLoginForm.ts`, `useReport.ts`, `schemas/report.ts`, `validation.ts`）— コメントのみでランタイムロジックは不変
- `.claude/rules/jsdoc.md` の「Lint による強制」節を実装済み内容に更新（有効ルールの唯一の真実は `eslint.config.mjs`）

### スコープ外（意図的に除外）

youtube-my-collection が同ファイルで束ねる以下は今回含めない:
- `eslint-config-prettier/flat`（本プロジェクトの ESLint は Prettier ルールを含まず不要）
- `@typescript-eslint/no-explicit-any` / `consistent-type-definitions`（jsdoc の範囲外・既存コードへの影響が別議論）

## テストメモ

- ✅ `pnpm lint` — 0 errors
- ✅ `pnpm typecheck` — pass
- ✅ `pnpm test` — 110/110 pass
- `.gitignore` 違反 / シークレット混入 / 大容量ファイル: なし（コミット前スキャン済み）

### ドキュメント影響マップ

Lint 設定（CI 静的解析）の変更だが `static-analysis` ジョブの構成（`pnpm lint` 実行）自体は不変のため `docs/04` の更新は不要。規約の実体は `.claude/rules/jsdoc.md` に反映済み。

## スクリーンショット

UI 変更なし（対象外）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)