### PR TITLE
docs(front): src 全体の JSDoc・コメントを充実

### DIFF
--- a/front/src/app/api/auth/admin/route.ts
+++ b/front/src/app/api/auth/admin/route.ts
@@ -5,6 +5,16 @@ const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL ?? '';
 const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? '';
 const supabase = createClient(supabaseUrl, supabaseAnonKey);
 
+/**
+ * リクエスト元が管理者かどうかを判定する（Supabase 認証モード用）。
+ *
+ * Authorization ヘッダの Bearer トークンで Supabase ユーザーを解決し、
+ * そのメールアドレスを `ADMIN_EMAIL`（カンマ区切り・大小無視）と照合する。
+ * 管理者判定はサーバー専用の `ADMIN_EMAIL` で行い、クライアントには公開しない。
+ *
+ * @param request - 受信リクエスト（Authorization ヘッダの Bearer トークンを参照）
+ * @returns 判定結果 `{ isAdmin }` の JSON。トークン欠如・検証失敗時は 401 で `{ isAdmin: false }`
+ */
 export async function GET(request: Request) {
   const authHeader = request.headers.get('authorization');
   const token = authHeader ? authHeader.replace(/^Bearer\s+/i, '').trim() : '';

--- a/front/src/app/api/auth/is-allowed/route.ts
+++ b/front/src/app/api/auth/is-allowed/route.ts
@@ -1,28 +1,61 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
 
+/** 許可判定 API のレスポンス形式（許可されていれば `allowed: true`）。 */
 type AllowedResponse = {
   allowed: boolean;
 };
 
+/**
+ * 許可メール一覧を `ADMIN_EMAIL` から取得する。
+ *
+ * カンマ区切りを分解し、前後空白除去・小文字化・空要素除去を行い比較用に正規化する。
+ *
+ * @returns 正規化済みの許可メールアドレス配列
+ */
 const getAllowedEmails = () =>
   (process.env.ADMIN_EMAIL ?? '')
     .split(',')
     .map((email) => email.trim().toLowerCase())
     .filter(Boolean);
 
+/**
+ * 指定メールが許可リストに含まれるかを判定する。
+ *
+ * メール未指定・許可リスト空はいずれも不許可扱い（フェイルクローズ）とする。
+ *
+ * @param email - 判定対象のメールアドレス（null/undefined 可）
+ * @returns 許可リストに含まれれば `true`、それ以外は `false`
+ */
 const isAllowedEmail = (email: string | null | undefined) => {
   const allowedEmails = getAllowedEmails();
   if (!email || allowedEmails.length === 0) return false;
   return allowedEmails.includes(email.toLowerCase());
 };
 
+/**
+ * Authorization ヘッダから Bearer トークンを取り出す。
+ *
+ * `Bearer ` 接頭辞が無い、またはトークンが空の場合は null を返す。
+ *
+ * @param request - 受信リクエスト（Authorization ヘッダを参照）
+ * @returns 抽出したアクセストークン。取得できなければ null
+ */
 const extractBearerToken = (request: NextRequest) => {
   const authorization = request.headers.get('authorization') ?? '';
   if (!authorization.startsWith('Bearer ')) return null;
   return authorization.slice('Bearer '.length).trim() || null;
 };
 
+/**
+ * ログイン許可対象のメールかを判定する。認証モードで検証方法が変わる。
+ *
+ * - local モード（E2E 専用）: リクエストボディの `email` を許可リストと照合する。
+ * - supabase モード（本番）: Bearer トークンで Supabase ユーザーを解決し、そのメールを照合する。
+ *
+ * @param request - 受信リクエスト（local はボディ、supabase は Authorization ヘッダを参照）
+ * @returns 判定結果 `{ allowed }` の JSON。トークン欠如・検証失敗時は 401、Supabase 環境変数不足時は 500
+ */
 export async function POST(request: NextRequest) {
   const authMode = process.env.NEXT_PUBLIC_AUTH_MODE ?? 'supabase';
 

--- a/front/src/app/api/reports/[id]/route.ts
+++ b/front/src/app/api/reports/[id]/route.ts
@@ -4,15 +4,25 @@ import { prisma } from '@/lib/db';
 import { validateReportInput, validateExternalUrls } from '@/lib/validation';
 import { requireAdmin } from '@/lib/auth-server';
 
+/** 動的ルート `[id]` のパラメータ（App Router 仕様で params は Promise）。 */
 type RouteParams = {
   params: Promise<{ id: string }>;
 };
 
+/** 詳細取得用の Report 行。タグマッピングと外部 URL を結合した型。 */
 type ReportWithTags = Report & {
   ReportTagMapping: (ReportTagMapping & { ReportTag: ReportTag })[];
   ExternalUrl: ExternalUrl[];
 };
 
+/**
+ * 詳細用の Report 行を API レスポンス形へ整形する。
+ *
+ * 詳細では本文（content）も含め、日付は ISO 文字列へ変換する。
+ *
+ * @param report - タグ・外部 URL を結合済みの詳細用 Report 行
+ * @returns 詳細項目としての Report オブジェクト
+ */
 const toReportItem = (report: ReportWithTags) => ({
   id: report.id,
   title: report.title,
@@ -27,6 +37,14 @@ const toReportItem = (report: ReportWithTags) => ({
   externalUrls: report.ExternalUrl.map((eu) => ({ id: eu.id, url: eu.url, label: eu.label })),
 });
 
+/**
+ * ID 指定でレポート詳細（本文含む）を返す（公開・認可不要）。
+ *
+ * レスポンスは CDN キャッシュ（`s-maxage=60, stale-while-revalidate=300`）を付与する。
+ *
+ * @param _request - 受信リクエスト（本ハンドラでは未使用だが署名上必須）
+ * @returns 詳細 Report の JSON。該当なしは 404、失敗時は 500 で `{ error }`
+ */
 export async function GET(_request: NextRequest, { params }: RouteParams) {
   try {
     const { id } = await params;
@@ -53,6 +71,16 @@ export async function GET(_request: NextRequest, { params }: RouteParams) {
   }
 }
 
+/**
+ * ID 指定でレポートを部分更新する（管理者のみ）。
+ *
+ * zod の partial 検証を用い、リクエストに含まれるフィールドだけを更新する。
+ * タグ・外部 URL は配列が渡された場合のみ全入れ替え（削除→再作成）する。
+ * すべてを単一トランザクションで実行する。
+ *
+ * @param request - 受信リクエスト（Authorization ヘッダで管理者判定、ボディに更新差分）
+ * @returns 更新後の Report の JSON。認可失敗は 401/403、検証エラーは 400、対象なしは 404、失敗時は 500
+ */
 export async function PATCH(request: NextRequest, { params }: RouteParams) {
   const auth = await requireAdmin(request, 'api/reports/[id]');
   if (!auth.ok) return auth.response;
@@ -71,6 +99,16 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
       return NextResponse.json({ errors: allErrors }, { status: 400 });
     }
 
+    /**
+     * 検証済みデータにキーが「存在するか」を判定する。
+     *
+     * 部分更新では「未指定のキーは更新しない」必要があり、値の真偽（null/空文字も有効値）
+     * ではなくキーの存在有無で更新対象を決めるため、hasOwnProperty で判定する。
+     *
+     * @param target - 判定対象のオブジェクト
+     * @param key - 存在を確認するキー
+     * @returns キーが存在すれば `true`
+     */
     const hasDataField = <T extends object, K extends keyof T>(target: T, key: K) =>
       Object.prototype.hasOwnProperty.call(target, key);
 
@@ -173,6 +211,7 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
   } catch (error) {
     console.error('[api/reports/[id]] PATCH failed', error);
     const code = typeof error === 'object' && error !== null && 'code' in error ? error.code : null;
+    // Prisma の P2025（更新対象レコードが存在しない）は 404 として扱う。
     if (code === 'P2025') {
       return NextResponse.json({ error: 'Not found' }, { status: 404 });
     }
@@ -180,6 +219,14 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
   }
 }
 
+/**
+ * ID 指定でレポートを削除する（管理者のみ）。
+ *
+ * 関連するタグマッピング・外部 URL は DB 側のカスケードに委ねる。
+ *
+ * @param request - 受信リクエスト（Authorization ヘッダで管理者判定）
+ * @returns 成功時 `{ ok: true }`。認可失敗は 401/403、対象なしは 404、失敗時は 500
+ */
 export async function DELETE(request: NextRequest, { params }: RouteParams) {
   const auth = await requireAdmin(request, 'api/reports/[id]');
   if (!auth.ok) return auth.response;
@@ -191,6 +238,7 @@ export async function DELETE(request: NextRequest, { params }: RouteParams) {
   } catch (error) {
     console.error('[api/reports/[id]] DELETE failed', error);
     const code = typeof error === 'object' && error !== null && 'code' in error ? error.code : null;
+    // Prisma の P2025（削除対象レコードが存在しない）は 404 として扱う。
     if (code === 'P2025') {
       return NextResponse.json({ error: 'Not found' }, { status: 404 });
     }

--- a/front/src/app/api/reports/route.ts
+++ b/front/src/app/api/reports/route.ts
@@ -4,15 +4,37 @@ import { prisma } from '@/lib/db';
 import { validateReportInput, validateExternalUrls } from '@/lib/validation';
 import { requireAdmin } from '@/lib/auth-server';
 
+/** タグマッピング行に、関連する `ReportTag` を結合した型。 */
 type TagMapping = ReportTagMapping & { ReportTag: ReportTag };
 
+/** 一覧取得用の Report 行。本文（content）は省き、タグと外部 URL を結合した型。 */
 type ReportListRow = Omit<Report, 'content'> & { ReportTagMapping: TagMapping[]; ExternalUrl: ExternalUrl[] };
 
+/**
+ * タグマッピングの配列からタグ名だけを取り出す。
+ *
+ * @param mappings - `ReportTag` を結合済みのタグマッピング配列
+ * @returns タグ名の配列
+ */
 const mapTags = (mappings: TagMapping[]) => mappings.map((m) => m.ReportTag.name);
 
+/**
+ * 外部 URL の Prisma 行を API レスポンス形へ整形する。
+ *
+ * @param urls - 外部 URL の Prisma 行配列
+ * @returns `{ id, url, label }` に絞った配列
+ */
 const mapExternalUrls = (urls: ExternalUrl[]) =>
   urls.map((eu) => ({ id: eu.id, url: eu.url, label: eu.label }));
 
+/**
+ * 一覧用の Report 行を API レスポンス形へ整形する。
+ *
+ * 一覧では本文を返さないため `content` は空文字にし、日付は ISO 文字列へ変換する。
+ *
+ * @param report - タグ・外部 URL を結合済みの一覧用 Report 行
+ * @returns 一覧項目としての Report オブジェクト
+ */
 const toReportListItem = (report: ReportListRow) => ({
   id: report.id,
   title: report.title,
@@ -27,6 +49,18 @@ const toReportListItem = (report: ReportListRow) => ({
   externalUrls: mapExternalUrls(report.ExternalUrl),
 });
 
+/**
+ * クエリ文字列を整数へ変換し、指定範囲にクランプする。
+ *
+ * 値が null・非数値なら undefined を返す。小数は切り捨て、`min`/`max` 指定時は
+ * 範囲外の値を境界値へ丸める（不正な limit/offset で過大なクエリを投げないための防御）。
+ *
+ * @param value - クエリ文字列の生値（未指定なら null）
+ * @param range - クランプ範囲
+ * @param range.min - 下限値（任意）。これ未満は下限へ丸める
+ * @param range.max - 上限値（任意）。これ超過は上限へ丸める
+ * @returns クランプ済みの整数。変換不能なら undefined
+ */
 const parseNumber = (value: string | null, range: { min?: number; max?: number } = {}) => {
   if (value === null) return undefined;
   const parsed = Number(value);
@@ -37,6 +71,16 @@ const parseNumber = (value: string | null, range: { min?: number; max?: number }
   return integer;
 };
 
+/**
+ * レポート一覧を新しい順で返す（公開・認可不要）。
+ *
+ * クエリ `limit`（1〜1000）/ `offset`（0〜）でページングし、総件数を `x-total-count`、
+ * limit 指定時は `x-limit`/`x-offset` をレスポンスヘッダに付与する。
+ * レスポンスは CDN キャッシュ（`s-maxage=60, stale-while-revalidate=300`）を付与する。
+ *
+ * @param request - 受信リクエスト（URL のクエリで `limit`/`offset` を受け取る）
+ * @returns 一覧項目の配列 JSON。失敗時は 500 で `{ error }`
+ */
 export async function GET(request: NextRequest) {
   try {
     const { searchParams } = new URL(request.url);
@@ -82,6 +126,15 @@ export async function GET(request: NextRequest) {
   }
 }
 
+/**
+ * レポートを新規作成する（管理者のみ）。
+ *
+ * 入力を zod で検証し、レポート本体・タグ（upsert してマッピング作成）・外部 URL を
+ * 単一トランザクションで登録する。作成結果を整形して返す。
+ *
+ * @param request - 受信リクエスト（Authorization ヘッダで管理者判定、ボディに作成内容）
+ * @returns 作成した Report を 201 で返す。認可失敗は 401/403、検証エラーは 400 で `{ errors }`、失敗時は 500
+ */
 export async function POST(request: NextRequest) {
   const auth = await requireAdmin(request, 'api/reports');
   if (!auth.ok) return auth.response;

--- a/front/src/app/api/tags/route.ts
+++ b/front/src/app/api/tags/route.ts
@@ -1,6 +1,13 @@
 import { NextResponse } from 'next/server';
 import { prisma } from '@/lib/db';
 
+/**
+ * タグ名の一覧を昇順で返す（公開・認可不要）。
+ *
+ * レスポンスは CDN キャッシュ（`s-maxage=60, stale-while-revalidate=300`）を付与する。
+ *
+ * @returns タグ名文字列の配列 JSON。失敗時は 500 で `{ error }`
+ */
 export async function GET() {
   try {
     const tags = await prisma.reportTag.findMany({

--- a/front/src/app/layout.tsx
+++ b/front/src/app/layout.tsx
@@ -21,6 +21,10 @@ export const metadata: Metadata = {
   description: 'A design-forward report journal for modern teams.',
 };
 
+/**
+ * アプリ全体のルートレイアウト（サーバーコンポーネント）。
+ * 全ページを `AppStateProvider` で包んでグローバル状態を供給し、フォント変数とメタデータを適用する。
+ */
 export default function RootLayout({
   children,
 }: Readonly<{

--- a/front/src/app/login/page.tsx
+++ b/front/src/app/login/page.tsx
@@ -3,6 +3,10 @@
 import LoginPage from '@/components/pages/LoginPage';
 import { useAppState } from '@/hooks/useAppState';
 
+/**
+ * ログイン画面（`/login`・クライアントコンポーネント）。
+ * `useAppState` からテーマとログイン手段（通常ログイン・Google OAuth）を取得し、`LoginPage` へ渡す。
+ */
 export default function LoginRoute() {
   const { theme, login, loginWithGoogle } = useAppState();
 

--- a/front/src/app/page.tsx
+++ b/front/src/app/page.tsx
@@ -4,6 +4,10 @@ import AppShell from '@/components/organisms/AppShell';
 import ListPage from '@/components/pages/ListPage';
 import { useAppState } from '@/hooks/useAppState';
 
+/**
+ * トップ画面（`/`・クライアントコンポーネント）。
+ * `useAppState` からテーマとレポート一覧を取得し、`AppShell` 内の `ListPage` へ渡して一覧を表示する。
+ */
 export default function HomePage() {
   const { theme, reports } = useAppState();
 

--- a/front/src/app/report/[id]/client.tsx
+++ b/front/src/app/report/[id]/client.tsx
@@ -6,6 +6,11 @@ import DetailPage from '@/components/pages/DetailPage';
 import { useAppState } from '@/hooks/useAppState';
 import { useReport } from '@/hooks/useReport';
 
+/**
+ * レポート詳細のクライアントコンポーネント。
+ * URL の ID から対象レポートを特定し、一覧のキャッシュを初期値に `useReport` で詳細（本文含む）を取得して、
+ * テーマ・ログインユーザー・削除ハンドラとともに `DetailPage` へ渡す。
+ */
 export default function ReportDetailClient() {
   const params = useParams();
   const { theme, reports, currentUser, deleteReport } = useAppState();

--- a/front/src/app/report/[id]/edit/client.tsx
+++ b/front/src/app/report/[id]/edit/client.tsx
@@ -6,6 +6,10 @@ import FormPage from '@/components/pages/FormPage';
 import { useAppState } from '@/hooks/useAppState';
 import { useReport } from '@/hooks/useReport';
 
+/**
+ * レポート編集のクライアントコンポーネント。
+ * URL の ID から対象レポートを取得し、更新ハンドラ（`updateReport`）とともに `FormPage` へ渡す。
+ */
 export default function ReportEditClient() {
   const params = useParams();
   const { theme, reports, currentUser, updateReport, isHydrated } = useAppState();
@@ -15,7 +19,7 @@ export default function ReportEditClient() {
 
   if (!reportId) return null;
 
-  // Pass the full report (with content) as a single-item array for useReportForm lookup
+  // 本文を含む完全なレポートを単一要素の配列で渡し、useReportForm 側の ID 検索に合わせる
   const reportsForForm = report ? [report] : [];
 
   return (

--- a/front/src/app/report/[id]/edit/page.tsx
+++ b/front/src/app/report/[id]/edit/page.tsx
@@ -1,11 +1,20 @@
 import ReportEditClient from './client';
 
+/** 事前生成していない ID もオンデマンドで動的レンダリングを許可する。 */
 export const dynamicParams = true;
 
+/**
+ * ビルド時に事前生成するパスを返す。空配列＝事前生成せず、全アクセスをオンデマンド生成に委ねる。
+ * 編集対象のレポートは実行時に DB から取得するため、ビルド時点で ID を列挙しない。
+ */
 export async function generateStaticParams() {
   return [];
 }
 
+/**
+ * レポート編集画面（`/report/[id]/edit`・サーバーコンポーネント）。
+ * クライアント側でルートパラメータと状態を扱うため、描画をクライアントコンポーネントへ委譲する。
+ */
 export default function ReportEditPage() {
   return <ReportEditClient />;
 }

--- a/front/src/app/report/[id]/page.tsx
+++ b/front/src/app/report/[id]/page.tsx
@@ -1,11 +1,20 @@
 import ReportDetailClient from './client';
 
+/** 事前生成していない ID もオンデマンドで動的レンダリングを許可する。 */
 export const dynamicParams = true;
 
+/**
+ * ビルド時に事前生成するパスを返す。空配列＝事前生成せず、全アクセスをオンデマンド生成に委ねる。
+ * レポートは実行時に DB から取得するため、ビルド時点で ID を列挙しない。
+ */
 export async function generateStaticParams() {
   return [];
 }
 
+/**
+ * レポート詳細画面（`/report/[id]`・サーバーコンポーネント）。
+ * クライアント側でルートパラメータと状態を扱うため、描画をクライアントコンポーネントへ委譲する。
+ */
 export default function ReportDetailPage() {
   return <ReportDetailClient />;
 }

--- a/front/src/app/report/markdown-lab/layout.tsx
+++ b/front/src/app/report/markdown-lab/layout.tsx
@@ -2,6 +2,10 @@ import { cookies } from 'next/headers';
 import { redirect } from 'next/navigation';
 import { AUTH_COOKIE_NAME } from '../../../constants';
 
+/**
+ * Markdown スタイル検証ラボの認証ゲート付きレイアウト（サーバーコンポーネント）。
+ * 認証 Cookie を検証し、未ログインなら `/login` へリダイレクトして配下のラボページへのアクセスを制限する。
+ */
 export default async function MarkdownLabLayout({
   children,
 }: Readonly<{

--- a/front/src/app/report/markdown-lab/page.tsx
+++ b/front/src/app/report/markdown-lab/page.tsx
@@ -4,6 +4,11 @@ import AppShell from '@/components/organisms/AppShell';
 import { useAppState } from '@/hooks/useAppState';
 import MarkdownLabPage from '@/components/pages/MarkdownLabPage';
 
+/**
+ * Markdown スタイル検証ラボ画面（`/report/markdown-lab`・クライアントコンポーネント）。
+ * Markdown 表示のスタイルを確認するための検証用ページ。認証は親レイアウトで必須化されている。
+ * `useAppState` からテーマを取得し `MarkdownLabPage` へ渡す。
+ */
 export default function ReportMarkdownLabRoute() {
   const { theme } = useAppState();
 

--- a/front/src/app/report/new/page.tsx
+++ b/front/src/app/report/new/page.tsx
@@ -4,6 +4,10 @@ import AppShell from '@/components/organisms/AppShell';
 import FormPage from '@/components/pages/FormPage';
 import { useAppState } from '@/hooks/useAppState';
 
+/**
+ * レポート新規作成画面（`/report/new`・クライアントコンポーネント）。
+ * `useAppState` からテーマ・ログインユーザー・新規追加ハンドラ（`addReport`）を取得し、空の `FormPage` を表示する。
+ */
 export default function ReportNewPage() {
   const { theme, currentUser, addReport, isHydrated } = useAppState();
 

--- a/front/src/components/atoms/AppLink.tsx
+++ b/front/src/components/atoms/AppLink.tsx
@@ -4,8 +4,14 @@ import React from 'react';
 import Link, { LinkProps } from 'next/link';
 import { useLoading } from '@/hooks/useLoading';
 
+/** next/link の props とアンカー要素の属性を合成した AppLink 用 props。 */
 type AppLinkProps = LinkProps & React.AnchorHTMLAttributes<HTMLAnchorElement>;
 
+/**
+ * 遷移時にローディング表示を起動する next/link ラッパー。
+ *
+ * クリック時に先にグローバルのローディングを開始してから、渡された onClick を実行する。
+ */
 const AppLink = ({ onClick, ...props }: AppLinkProps) => {
   const { startLoading } = useLoading();
 

--- a/front/src/components/atoms/Avatar.tsx
+++ b/front/src/components/atoms/Avatar.tsx
@@ -3,8 +3,11 @@
 import React from 'react';
 
 interface AvatarProps {
+  /** 表示名。先頭 1 文字をイニシャルとして描画する。 */
   name: string;
+  /** サイズ。省略時は 'sm'（小）。 */
   size?: 'sm' | 'md';
+  /** 追加の Tailwind クラス。 */
   className?: string;
 }
 
@@ -13,6 +16,7 @@ const sizeClasses = {
   md: 'w-12 h-12',
 };
 
+/** 表示名のイニシャル（先頭 1 文字）を丸く表示する最小のアバター部品。 */
 const Avatar: React.FC<AvatarProps> = ({ name, size = 'sm', className = '' }) => {
   return (
     <div

--- a/front/src/components/atoms/Badge.tsx
+++ b/front/src/components/atoms/Badge.tsx
@@ -3,10 +3,13 @@
 import React from 'react';
 
 interface BadgeProps {
+  /** バッジ内に表示する内容（ラベル文字列など）。 */
   children: React.ReactNode;
+  /** 追加の Tailwind クラス（色などの見た目を上書きする）。 */
   className?: string;
 }
 
+/** カテゴリやステータスを示す小さなラベル用の最小 UI 部品。 */
 const Badge: React.FC<BadgeProps> = ({ children, className = '' }) => {
   return (
     <span

--- a/front/src/components/atoms/Button.tsx
+++ b/front/src/components/atoms/Button.tsx
@@ -2,8 +2,10 @@
 
 import React from 'react';
 
+/** 標準の button 要素属性をそのまま受け取る Button 用 props。 */
 type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement>;
 
+/** 汎用ボタン。共通のトランジション/カーソル指定を付与し、残りの属性はそのまま透過する。 */
 const Button: React.FC<ButtonProps> = ({ className = '', ...props }) => {
   return (
     <button

--- a/front/src/components/atoms/Input.tsx
+++ b/front/src/components/atoms/Input.tsx
@@ -2,8 +2,10 @@
 
 import React from 'react';
 
+/** 標準の input 要素属性をそのまま受け取る Input 用 props。 */
 type InputProps = React.InputHTMLAttributes<HTMLInputElement>;
 
+/** 汎用テキスト入力。共通の基本スタイルを付与し、残りの属性はそのまま透過する。 */
 const Input: React.FC<InputProps> = ({ className = '', ...props }) => {
   return (
     <input

--- a/front/src/components/atoms/SectionLabel.tsx
+++ b/front/src/components/atoms/SectionLabel.tsx
@@ -3,11 +3,15 @@
 import React from 'react';
 
 interface SectionLabelProps {
+  /** ラベルとして表示する内容。 */
   children: React.ReactNode;
+  /** 追加の Tailwind クラス。 */
   className?: string;
+  /** 紐付ける入力要素の id（label の for 属性）。 */
   htmlFor?: string;
 }
 
+/** セクション見出しやフォーム項目のラベルに使う、小さな大文字調のラベル部品。 */
 const SectionLabel: React.FC<SectionLabelProps> = ({ children, className = '', htmlFor }) => {
   return (
     <label htmlFor={htmlFor} className={`text-xs uppercase tracking-widest font-bold ${className}`}>

--- a/front/src/components/atoms/Select.tsx
+++ b/front/src/components/atoms/Select.tsx
@@ -2,8 +2,10 @@
 
 import React from 'react';
 
+/** 標準の select 要素属性をそのまま受け取る Select 用 props。 */
 type SelectProps = React.SelectHTMLAttributes<HTMLSelectElement>;
 
+/** 汎用セレクトボックス。共通の基本スタイルを付与し、残りの属性はそのまま透過する。 */
 const Select: React.FC<SelectProps> = ({ className = '', children, ...props }) => {
   return (
     <select

--- a/front/src/components/atoms/Spinner.tsx
+++ b/front/src/components/atoms/Spinner.tsx
@@ -3,10 +3,13 @@
 import React from 'react';
 
 interface SpinnerProps {
+  /** 追加の Tailwind クラス（配置などの調整用）。 */
   className?: string;
+  /** スピナー下に表示する文言。省略時は 'Loading'。 */
   label?: string;
 }
 
+/** ローディング中を示す回転インジケータとラベルを表示する最小 UI 部品。 */
 const Spinner: React.FC<SpinnerProps> = ({ className = '', label = 'Loading' }) => {
   return (
     <div className={`flex flex-col items-center gap-3 ${className}`}>

--- a/front/src/components/atoms/TagChip.tsx
+++ b/front/src/components/atoms/TagChip.tsx
@@ -3,12 +3,21 @@
 import React from 'react';
 
 interface TagChipProps {
+  /** チップに表示するタグ名。 */
   label: string;
+  /** 追加の Tailwind クラス。 */
   className?: string;
+  /** クリック時のハンドラ。指定した場合のみボタンとして描画され、押下操作が可能になる。 */
   onClick?: () => void;
+  /** 選択状態。onClick 指定時に aria-pressed へ反映する。 */
   selected?: boolean;
 }
 
+/**
+ * タグを表す小さなチップ部品。
+ *
+ * onClick の有無で振る舞いを変え、指定時は押下可能な button、未指定時は静的な span として描画する。
+ */
 const TagChip: React.FC<TagChipProps> = ({ label, className = '', onClick, selected }) => {
   const Tag = onClick ? 'button' : 'span';
 

--- a/front/src/components/atoms/TextArea.tsx
+++ b/front/src/components/atoms/TextArea.tsx
@@ -2,8 +2,10 @@
 
 import React from 'react';
 
+/** 標準の textarea 要素属性をそのまま受け取る TextArea 用 props。 */
 type TextAreaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>;
 
+/** 汎用複数行入力。共通の基本スタイルを付与し、残りの属性はそのまま透過する。 */
 const TextArea: React.FC<TextAreaProps> = ({ className = '', ...props }) => {
   return (
     <textarea

--- a/front/src/components/molecules/AuthorInfo.tsx
+++ b/front/src/components/molecules/AuthorInfo.tsx
@@ -4,14 +4,23 @@ import React from 'react';
 import Avatar from '@/components/atoms/Avatar';
 
 interface AuthorInfoProps {
+  /** 著者名。アバターの頭文字生成にも使う。 */
   name: string;
+  /** 肩書き。指定時は subtitle より優先して大文字ラベルで表示する。 */
   role?: string;
+  /** 補足テキスト。role 未指定のときのみ表示する。 */
   subtitle?: string;
+  /** アバターのサイズ。未指定時は `sm`。 */
   avatarSize?: 'sm' | 'md';
+  /** アバターへ付与する追加クラス。 */
   avatarClassName?: string;
+  /** 著者名へ付与する追加クラス。 */
   nameClassName?: string;
+  /** role / subtitle へ付与する追加クラス。 */
   subtitleClassName?: string;
 }
+
+/** アバターと著者名（＋肩書き/補足）を横並びで表示する。role と subtitle は role 優先で排他表示。 */
 
 const AuthorInfo: React.FC<AuthorInfoProps> = ({
   name,

--- a/front/src/components/molecules/CategoryButton.tsx
+++ b/front/src/components/molecules/CategoryButton.tsx
@@ -4,11 +4,17 @@ import React from 'react';
 import Button from '@/components/atoms/Button';
 
 interface CategoryButtonProps {
+  /** 表示するカテゴリ名。 */
   category: string;
+  /** 選択中かどうか。true で太字＋下線を付け、`aria-pressed` にも反映する。 */
   selected: boolean;
+  /** ボタン押下時に呼ぶ。 */
   onClick: () => void;
+  /** 文字色などの追加クラス。 */
   textClassName?: string;
 }
+
+/** カテゴリ絞り込み用のトグルボタン。選択状態を太字＋下線と `aria-pressed` で示す。 */
 
 const CategoryButton: React.FC<CategoryButtonProps> = ({
   category,

--- a/front/src/components/molecules/ExternalUrlFieldList.tsx
+++ b/front/src/components/molecules/ExternalUrlFieldList.tsx
@@ -5,16 +5,27 @@ import ExternalUrlInput from './ExternalUrlInput';
 import { ExternalUrlInput as ExternalUrlInputType } from '@/types';
 
 interface ExternalUrlFieldListProps {
+  /** 編集中の外部URL入力行の配列。index が各行の識別子を兼ねる。 */
   urls: ExternalUrlInputType[];
+  /** フィールド単位のエラー。キーは `externalUrls.{index}.url` / `externalUrls.{index}.label` 形式で各行に紐付く。 */
   fieldErrors?: Record<string, string>;
+  /** 「+ URL追加」押下時に呼ぶ。新しい空行の追加を親に委ねる。 */
   onAdd: () => void;
+  /** 行の削除ボタン押下時に呼ぶ。引数は対象行の index。 */
   onRemove: (index: number) => void;
+  /** URL入力変更時に呼ぶ。引数は対象行の index と新しい値。 */
   onChangeUrl: (index: number, value: string) => void;
+  /** ラベル入力変更時に呼ぶ。引数は対象行の index と新しい値。 */
   onChangeLabel: (index: number, value: string) => void;
+  /** 見出しへ付与する追加クラス。 */
   labelClassName?: string;
+  /** 各入力の枠線クラス。子の ExternalUrlInput に委譲する。 */
   borderClass?: string;
+  /** 各入力の角丸クラス。子の ExternalUrlInput に委譲する。 */
   borderRadiusClass?: string;
 }
+
+/** 外部URL入力行のリスト。各行を ExternalUrlInput で描画し、追加/削除/変更を親コールバックへ委ねる。 */
 
 const ExternalUrlFieldList: React.FC<ExternalUrlFieldListProps> = ({
   urls,

--- a/front/src/components/molecules/ExternalUrlInput.tsx
+++ b/front/src/components/molecules/ExternalUrlInput.tsx
@@ -3,16 +3,27 @@
 import React from 'react';
 
 interface ExternalUrlInputProps {
+  /** URL入力の現在値。 */
   url: string;
+  /** ラベル入力の現在値（任意項目）。 */
   label: string;
+  /** URL欄のエラーメッセージ。あるときのみ赤字で表示する。 */
   urlError?: string;
+  /** ラベル欄のエラーメッセージ。あるときのみ赤字で表示する。 */
   labelError?: string;
+  /** URL入力変更時に呼ぶ。引数は新しい値。 */
   onChangeUrl: (value: string) => void;
+  /** ラベル入力変更時に呼ぶ。引数は新しい値。 */
   onChangeLabel: (value: string) => void;
+  /** ✕ボタン押下時に呼ぶ。この行の削除を親に委ねる。 */
   onRemove: () => void;
+  /** 入力欄の枠線クラス。 */
   borderClass?: string;
+  /** 入力欄の角丸クラス。 */
   borderRadiusClass?: string;
 }
+
+/** 外部URL1件分の入力行。URL・ラベルの2入力と削除ボタンを並べ、各欄のエラーを直下に表示する。 */
 
 const ExternalUrlInput: React.FC<ExternalUrlInputProps> = ({
   url,

--- a/front/src/components/molecules/ExternalUrlLinks.tsx
+++ b/front/src/components/molecules/ExternalUrlLinks.tsx
@@ -4,16 +4,22 @@ import React from 'react';
 import { ExternalUrlItem } from '@/types';
 
 interface ExternalUrlLinksProps {
+  /** 表示する外部URLの配列。空なら何も描画しない。 */
   urls: ExternalUrlItem[];
+  /** 見出しへ付与する追加クラス。 */
   labelClassName?: string;
+  /** 各リンクへ付与する追加クラス。 */
   linkClassName?: string;
 }
+
+/** レポート詳細の外部リンク一覧を表示する。URLが無ければ描画しない。各リンクは別タブ（`rel=noopener`）で開く。 */
 
 const ExternalUrlLinks: React.FC<ExternalUrlLinksProps> = ({
   urls,
   labelClassName,
   linkClassName,
 }) => {
+  // URLが1件も無ければ見出しごと非表示にする。
   if (urls.length === 0) return null;
 
   return (

--- a/front/src/components/molecules/FilterIndicator.tsx
+++ b/front/src/components/molecules/FilterIndicator.tsx
@@ -4,12 +4,19 @@ import React from 'react';
 import Button from '@/components/atoms/Button';
 
 interface FilterIndicatorProps {
+  /** 選択中のカテゴリ。null なら未選択でバッジを出さない。 */
   category: string | null;
+  /** 選択中のタグ。null なら未選択でバッジを出さない。 */
   tag: string | null;
+  /** 「Clear」押下時に呼ぶ。フィルタ解除を親に委ねる。 */
   onClear: () => void;
+  /** バッジへ付与する追加クラス。 */
   badgeClassName?: string;
+  /** 補助テキスト（Filter ラベル/Clear ボタン）へ付与する追加クラス。 */
   mutedClassName?: string;
 }
+
+/** 適用中のカテゴリ/タグフィルタをバッジ表示し、解除ボタンを出す。どちらも未選択なら描画しない。 */
 
 const FilterIndicator: React.FC<FilterIndicatorProps> = ({
   category,
@@ -18,6 +25,7 @@ const FilterIndicator: React.FC<FilterIndicatorProps> = ({
   badgeClassName = '',
   mutedClassName = '',
 }) => {
+  // カテゴリ・タグとも未選択ならフィルタ表示自体を出さない。
   if (!category && !tag) return null;
 
   return (

--- a/front/src/components/molecules/FormField.tsx
+++ b/front/src/components/molecules/FormField.tsx
@@ -4,11 +4,17 @@ import React, { useId } from 'react';
 import SectionLabel from '@/components/atoms/SectionLabel';
 
 interface FormFieldProps {
+  /** ラベル文言。 */
   label: string;
+  /** ラベルへ付与する追加クラス。 */
   labelClassName?: string;
+  /** エラーメッセージ。あるときのみ入力の下に赤字で表示する。 */
   error?: string | null;
+  /** 入力要素を返すレンダープロップ。引数の id をラベルと入力の紐付け（htmlFor/id）に使う。 */
   children: (id: string) => React.ReactNode;
 }
+
+/** ラベル＋入力＋エラーを縦に並べるフォーム部品。`useId` で採番した id を children に渡しラベルと入力を関連付ける。 */
 
 const FormField: React.FC<FormFieldProps> = ({
   label,

--- a/front/src/components/molecules/NavLink.tsx
+++ b/front/src/components/molecules/NavLink.tsx
@@ -4,10 +4,15 @@ import React from 'react';
 import AppLink from '@/components/atoms/AppLink';
 
 interface NavLinkProps {
+  /** リンク先パス/URL。 */
   href: string;
+  /** 追加クラス。ホバー時の不透明度アニメーションに上乗せする。 */
   className?: string;
+  /** リンクのラベル要素。 */
   children: React.ReactNode;
 }
+
+/** ホバーで薄くなるナビゲーション用リンク。内部リンクは AppLink に委譲する。 */
 
 const NavLink: React.FC<NavLinkProps> = ({ href, className = '', children }) => {
   return (

--- a/front/src/components/molecules/PaginationNav.tsx
+++ b/front/src/components/molecules/PaginationNav.tsx
@@ -4,16 +4,27 @@ import React from 'react';
 import Button from '@/components/atoms/Button';
 
 interface PaginationNavProps {
+  /** 現在ページ（1始まり）。前へ/次への活性判定と現在番号の強調に使う。 */
   currentPage: number;
+  /** 総ページ数。1以下なら nav 自体を描画しない。 */
   totalPages: number;
+  /** 表示するページ番号の配列。省略表示などの計算は親側で行う前提。 */
   pageNumbers: number[];
+  /** ページ遷移時に呼ぶ。引数は遷移先ページ。 */
   onPageChange: (page: number) => void;
+  /** ボタン枠線の追加クラス。 */
   borderClassName?: string;
+  /** ボタン角丸の追加クラス。 */
   borderRadius?: string;
+  /** 非選択ボタンの背景（サーフェス）クラス。 */
   surfaceClassName?: string;
+  /** ボタン文字色の追加クラス。 */
   textClassName?: string;
+  /** 現在ページボタンの強調（アクセント背景）クラス。 */
   accentClassName?: string;
 }
+
+/** 一覧のページネーション。1ページ以下なら描画しない。前へ/次へと番号ボタンを出す。 */
 
 const PaginationNav: React.FC<PaginationNavProps> = ({
   currentPage,
@@ -26,6 +37,7 @@ const PaginationNav: React.FC<PaginationNavProps> = ({
   textClassName = '',
   accentClassName = '',
 }) => {
+  // 1ページ以下ならページ送りが不要なので nav ごと描画しない。
   if (totalPages <= 1) return null;
 
   return (

--- a/front/src/components/molecules/ReportCardMeta.tsx
+++ b/front/src/components/molecules/ReportCardMeta.tsx
@@ -4,11 +4,17 @@ import React from 'react';
 import Badge from '@/components/atoms/Badge';
 
 interface ReportCardMetaProps {
+  /** カテゴリ名。バッジで表示する。 */
   category: string;
+  /** 表示用の日付文字列（整形済みを渡す前提）。 */
   date: string;
+  /** バッジへ付与する追加クラス。 */
   badgeClassName?: string;
+  /** 日付テキストへ付与する追加クラス。 */
   dateClassName?: string;
 }
+
+/** レポートカードのメタ情報行。カテゴリバッジと日付を横並びで表示する。 */
 
 const ReportCardMeta: React.FC<ReportCardMetaProps> = ({
   category,

--- a/front/src/components/molecules/UserAuthSection.tsx
+++ b/front/src/components/molecules/UserAuthSection.tsx
@@ -4,13 +4,21 @@ import React from 'react';
 import Button from '@/components/atoms/Button';
 
 interface UserAuthSectionProps {
+  /** ログイン中ユーザーの表示名。 */
   username: string;
+  /** 「Logout」押下時に呼ぶ。ログアウト処理を親に委ねる。 */
   onLogout: () => void;
+  /** 補助ラベル（Authenticated as）へ付与する追加クラス。 */
   mutedClassName?: string;
+  /** ユーザー名へ付与する追加クラス。 */
   textClassName?: string;
+  /** ログアウトボタンの強調（アクセント背景）クラス。 */
   accentClassName?: string;
+  /** ログアウトボタンの角丸クラス。 */
   borderRadius?: string;
 }
+
+/** ヘッダー右部の認証状態表示。ログイン中ユーザー名とログアウトボタンを並べる。 */
 
 const UserAuthSection: React.FC<UserAuthSectionProps> = ({
   username,

--- a/front/src/components/organisms/AppShell.tsx
+++ b/front/src/components/organisms/AppShell.tsx
@@ -9,6 +9,11 @@ import LoadingOverlay from './LoadingOverlay';
 import { LoadingProvider } from '@/providers/LoadingContext';
 import { useAppState } from '@/hooks/useAppState';
 
+/**
+ * アプリ全体のレイアウト骨格。Header / Sidebar / Footer と本文（children）を配置し、
+ * 初回ハイドレーションおよびルート遷移時のローディングオーバーレイ表示を制御する。
+ * ローディング開始トリガーは `LoadingProvider` 経由で配下コンポーネントへ公開する。
+ */
 const AppShell = ({ children }: { children: React.ReactNode }) => {
   const {
     theme,
@@ -36,6 +41,12 @@ const AppShell = ({ children }: { children: React.ReactNode }) => {
     }
   }, []);
 
+  /**
+   * 指定遅延後にオーバーレイのフェードアウトを予約する。
+   * 既存タイマーがあればクリアして常に最新の1本だけを走らせる（多重発火防止）。
+   *
+   * @param delayMs - フェードアウト開始までの遅延（ms）
+   */
   const scheduleFadeOut = (delayMs: number) => {
     if (loadingTimerRef.current) {
       clearTimeout(loadingTimerRef.current);
@@ -43,6 +54,7 @@ const AppShell = ({ children }: { children: React.ReactNode }) => {
     loadingTimerRef.current = setTimeout(() => setFadeOutLoading(true), delayMs);
   };
 
+  /** オーバーレイを即時表示し、最短表示時間の経過後にフェードアウトを予約する。 */
   const startLoading = () => {
     setShowLoading(true);
     setFadeOutLoading(false);
@@ -50,6 +62,10 @@ const AppShell = ({ children }: { children: React.ReactNode }) => {
     scheduleFadeOut(minDurationMs);
   };
 
+  /**
+   * 配下コンポーネントからの手動ローディング開始。
+   * 発火時刻を記録し、直後に走るルート遷移由来の二重表示を抑止する。
+   */
   const triggerLoading = () => {
     lastManualTriggerRef.current = Date.now();
     startLoading();

--- a/front/src/components/organisms/ConfirmationModal.tsx
+++ b/front/src/components/organisms/ConfirmationModal.tsx
@@ -3,16 +3,31 @@
 import React, { useState } from 'react';
 import { DesignSystem } from '@/types';
 
+/** 確認モーダルの props。 */
 interface ConfirmationModalProps {
+  /** 配色・フォント・角丸などのデザインシステム */
   theme: DesignSystem;
+  /** モーダルの表示可否（false のとき何もレンダリングしない） */
   isOpen: boolean;
+  /** キャンセル/確定完了時にモーダルを閉じるコールバック */
   onClose: () => void;
+  /** 確定時の処理。非同期可。reject 時はモーダルを閉じず送信状態を復帰する */
   onConfirm: () => void | Promise<void>;
+  /** 見出しに表示するタイトル */
   title: string;
+  /** 本文に表示する説明メッセージ */
   message: string;
+  /** 確定ボタンのラベル */
   confirmLabel: string;
+  /** 確定ボタンの見た目。破壊的操作は `danger`（赤系）。既定は `primary` */
   confirmVariant?: 'primary' | 'danger';
 }
+
+/**
+ * 破壊的操作などの実行前に確認を求める汎用モーダル。
+ * 確定処理中は両ボタンを無効化して二重送信を防止し、`onConfirm` が失敗した場合は
+ * モーダルを閉じずに送信状態を復帰させて再操作を可能にする。
+ */
 
 const ConfirmationModal: React.FC<ConfirmationModalProps> = ({
   theme,
@@ -32,6 +47,7 @@ const ConfirmationModal: React.FC<ConfirmationModalProps> = ({
 
   return (
     <div className="fixed inset-0 z-[100] flex items-center justify-center p-4 bg-black/40 backdrop-blur-sm animate-in fade-in duration-200">
+      {/* パネル内クリックが背景オーバーレイへ伝播するのを止める（誤クローズ防止） */}
       <div
         className={`${colors.surface} ${colors.border} border p-8 max-w-md w-full shadow-2xl ${borderRadius} animate-in zoom-in-95 duration-200`}
         onClick={(event) => event.stopPropagation()}
@@ -50,13 +66,14 @@ const ConfirmationModal: React.FC<ConfirmationModalProps> = ({
           <button
             disabled={isSubmitting}
             onClick={async () => {
+              // 送信中の再クリックを弾いて二重実行を防ぐ
               if (isSubmitting) return;
               setIsSubmitting(true);
               try {
                 await onConfirm();
                 onClose();
               } catch {
-                // onConfirm rejected; isSubmitting is reset via finally
+                // onConfirm が失敗: モーダルは閉じない。送信状態は finally で復帰し再操作可能にする
               } finally {
                 setIsSubmitting(false);
               }

--- a/front/src/components/organisms/Footer.tsx
+++ b/front/src/components/organisms/Footer.tsx
@@ -3,10 +3,16 @@
 import React from 'react';
 import { DesignSystem } from '@/types';
 
+/** フッターの props。 */
 interface FooterProps {
+  /** 配色・フォントなどのデザインシステム */
   theme: DesignSystem;
 }
 
+/**
+ * ページ最下部に固定表示するフッター。
+ * アプリ名・説明と、現在の年を反映した著作権表記を表示する。
+ */
 const Footer: React.FC<FooterProps> = ({ theme }) => {
   const { colors, fontHeader } = theme;
 

--- a/front/src/components/organisms/Header.tsx
+++ b/front/src/components/organisms/Header.tsx
@@ -6,12 +6,21 @@ import NavLink from '@/components/molecules/NavLink';
 import UserAuthSection from '@/components/molecules/UserAuthSection';
 import { DesignSystem, User } from '@/types';
 
+/** ヘッダーの props。 */
 interface HeaderProps {
+  /** 配色・フォント・ヘッダー配置スタイルなどのデザインシステム */
   theme: DesignSystem;
+  /** ログイン中ユーザー。未ログイン時は `null` */
   user: User | null;
+  /** ログアウト操作のコールバック */
   onLogout: () => void;
 }
 
+/**
+ * グローバルヘッダー。ロゴとナビゲーションを表示する。
+ * ログイン時は投稿系リンクとユーザー認証セクションを、未ログイン時はログインボタンを出し分ける。
+ * `theme.headerStyle === 'sticky'` の場合は画面上部に固定する。
+ */
 const Header: React.FC<HeaderProps> = ({ theme, user, onLogout }) => {
   const { colors, fontHeader, headerStyle, borderRadius } = theme;
 

--- a/front/src/components/organisms/LoadingOverlay.tsx
+++ b/front/src/components/organisms/LoadingOverlay.tsx
@@ -3,12 +3,21 @@
 import React from 'react';
 import Spinner from '@/components/atoms/Spinner';
 
+/** ローディングオーバーレイの props。 */
 interface LoadingOverlayProps {
+  /** オーバーレイの表示可否（false のとき何もレンダリングしない） */
   visible: boolean;
+  /** true でフェードアウト（透明化）を開始する。既定は false */
   fadeOut?: boolean;
+  /** フェードアウトのトランジション完了時に呼ばれるコールバック */
   onFadeOutEnd?: () => void;
 }
 
+/**
+ * 画面全体を覆うローディングオーバーレイ。中央にスピナーを表示する。
+ * `fadeOut` で透明化し、CSS トランジション完了（`onTransitionEnd`）を検知して
+ * `onFadeOutEnd` を呼ぶことで、呼び出し側が実際の非表示（アンマウント）を制御できる。
+ */
 const LoadingOverlay: React.FC<LoadingOverlayProps> = ({
   visible,
   fadeOut = false,

--- a/front/src/components/organisms/LoginForm.tsx
+++ b/front/src/components/organisms/LoginForm.tsx
@@ -5,12 +5,21 @@ import LoadingOverlay from './LoadingOverlay';
 import { useLoginForm } from '@/hooks/useLoginForm';
 import { DesignSystem } from '@/types';
 
+/** ログインフォームの props。 */
 interface LoginFormProps {
+  /** 配色・フォント・角丸などのデザインシステム */
   theme: DesignSystem;
+  /** メール/パスワードによるログイン処理。成功時 `null`、失敗時はエラーメッセージを返す */
   onLogin: (email: string, password: string) => Promise<string | null>;
+  /** Google OAuth ログイン処理。成功時 `null`、失敗時はエラーメッセージを返す */
   onLoginWithGoogle: () => Promise<string | null>;
 }
 
+/**
+ * ログイン画面のフォーム。認証状態は `useLoginForm` フックに委譲し、本体は描画に専念する。
+ * `NEXT_PUBLIC_AUTH_MODE` により入力手段を出し分ける:
+ * `local`（E2E 専用）はメール/パスワード入力、既定の `supabase` は Google OAuth ボタンを表示する。
+ */
 const LoginForm: React.FC<LoginFormProps> = ({ theme, onLogin, onLoginWithGoogle }) => {
   const {
     email,
@@ -24,6 +33,7 @@ const LoginForm: React.FC<LoginFormProps> = ({ theme, onLogin, onLoginWithGoogle
   } = useLoginForm({ onLogin, onLoginWithGoogle });
 
   const { colors, fontHeader, borderRadius } = theme;
+  // 認証モード。未設定時は本番想定の supabase（Google OAuth）にフォールバックする
   const authMode = process.env.NEXT_PUBLIC_AUTH_MODE ?? 'supabase';
 
   return (

--- a/front/src/components/organisms/ReportMarkdown.tsx
+++ b/front/src/components/organisms/ReportMarkdown.tsx
@@ -5,12 +5,23 @@ import ReactMarkdown, { type Components } from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import rehypeSanitize from 'rehype-sanitize';
 
+/** Markdown レポート表示の props。 */
 interface ReportMarkdownProps {
+  /** 表示対象の Markdown 本文 */
   content: string;
+  /** 見た目のバリアント（スタイル切り替え用のクラス接尾辞）。既定は `v7` */
   variant?: 'v7';
+  /** ルート要素へ付与する追加クラス名 */
   className?: string;
 }
 
+/**
+ * React 要素の子を素朴なプレーンテキストへ平坦化する。
+ * 文字列・数値・`<br>`（改行に変換）のみを許容し、それ以外の要素が含まれる場合は
+ * 「単純な段落ではない」と判断して `null` を返す（後段の箇条書き変換をスキップさせるため）。
+ *
+ * @param children - 段落 `<p>` がレンダリングする子ノード
+ */
 const toPlainText = (children: React.ReactNode): string | null => {
   const nodes = React.Children.toArray(children);
   let text = '';
@@ -29,6 +40,14 @@ const toPlainText = (children: React.ReactNode): string | null => {
   return text;
 };
 
+/**
+ * 全行が全角中点「・」で始まる段落を、箇条書き（li）項目の配列へ変換する。
+ * Markdown 標準のリスト記法ではなく「・」書きで箇条書きされた原稿を、
+ * 見た目上のリストとして描画するための独自変換。1 行でも「・」始まりでない行が
+ * あれば箇条書きとみなさず `null` を返し、通常の段落として扱わせる。
+ *
+ * @param text - 段落のプレーンテキスト（`toPlainText` で平坦化済み）
+ */
 const parseDotListItems = (text: string): string[] | null => {
   const lines = text
     .split('\n')
@@ -45,13 +64,21 @@ const parseDotListItems = (text: string): string[] | null => {
   return items as string[];
 };
 
+/** セクションの種類。`normal` 以外はコールアウト（強調ボックス）として描画される。 */
 type SectionKind = 'normal' | 'summary' | 'warning' | 'trend';
 
-// 見出しテキストから特別セクション（結論 / 注意 / 動向）を判定する
+// 見出しテキストから特別セクション（まとめ / 注意 / 動向）を判定するためのパターン。
+// 見出し語に以下のキーワードを含む h2 を、対応するコールアウト種別として扱う。
 const SUMMARY_RE = /(まとめ|総括|示唆|サマリー|サマリ)/;
 const WARNING_RE = /(注意点|注意事項|懸念|リスク)/;
 const TREND_RE = /(トレンド|動向|傾向)/;
 
+/**
+ * 見出しテキストからセクション種別を判定する。
+ * まとめ→注意→動向の優先順で最初に一致した種別を返し、いずれにも該当しなければ `normal`。
+ *
+ * @param heading - h2 見出しの行テキスト
+ */
 const classifyHeading = (heading: string): SectionKind => {
   if (SUMMARY_RE.test(heading)) return 'summary';
   if (WARNING_RE.test(heading)) return 'warning';
@@ -84,6 +111,10 @@ const splitSections = (content: string): { kind: SectionKind; content: string }[
     .filter((section) => section.content.trim().length > 0);
 };
 
+/**
+ * react-markdown のノード別描画をカスタマイズする定義。
+ * 段落は「・」書き箇条書きを検出した場合のみ ul へ差し替える（それ以外は素の段落）。
+ */
 const markdownComponents: Components = {
   p: ({ children }) => {
     const text = toPlainText(children);
@@ -104,11 +135,20 @@ const markdownComponents: Components = {
   },
 };
 
+/**
+ * Markdown 断片を React 要素へ描画する。
+ * GFM（remark-gfm）を有効化しつつ、`rehypeSanitize` で必ずサニタイズして
+ * ユーザー入力由来の生 HTML による XSS を防ぐ（デフォルトスキーマ使用）。このサニタイズは必須。
+ *
+ * @param content - 描画対象の Markdown 断片
+ */
 const renderMarkdown = (content: string) => (
   <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeSanitize]} components={markdownComponents}>
     {content}
   </ReactMarkdown>
 );
+
+/** `normal` 以外のセクション種別を、対応するコールアウト用 CSS クラスへ対応づける。 */
 
 const CALLOUT_CLASS: Record<Exclude<SectionKind, 'normal'>, string> = {
   summary: 'report-callout report-callout--summary',
@@ -116,6 +156,12 @@ const CALLOUT_CLASS: Record<Exclude<SectionKind, 'normal'>, string> = {
   trend: 'report-callout report-callout--trend',
 };
 
+/**
+ * レポート本文の Markdown を描画するビューア。
+ * 本文を h2 見出しでセクション分割し、見出し語から判定した種別（まとめ/注意/動向）の
+ * セクションはコールアウト（強調ボックス）で囲んで描画する。描画はすべて `rehypeSanitize`
+ * 経由でサニタイズされる。
+ */
 const ReportMarkdown: React.FC<ReportMarkdownProps> = ({ content, variant = 'v7', className = '' }) => {
   const sections = splitSections(content);
 

--- a/front/src/components/organisms/Sidebar.tsx
+++ b/front/src/components/organisms/Sidebar.tsx
@@ -5,15 +5,27 @@ import CategoryButton from '@/components/molecules/CategoryButton';
 import { DesignSystem } from '@/types';
 import { CATEGORIES } from '@/constants';
 
+/** サイドバーの props。 */
 interface SidebarProps {
+  /** 配色・フォント・サイドバー配置スタイルなどのデザインシステム */
   theme: DesignSystem;
+  /** 表示候補となるタグの生リスト（重複・先頭 `#`・空白を含みうる） */
   tags: string[];
+  /** 現在選択中のカテゴリ。未選択時は `null` */
   selectedCategory: string | null;
+  /** カテゴリ選択の切り替えコールバック（解除時は `null`） */
   onSelectCategory: (category: string | null) => void;
+  /** 現在選択中のタグ（正規化済みの value）。未選択時は `null` */
   selectedTag: string | null;
+  /** タグ選択の切り替えコールバック（解除時は `null`） */
   onSelectTag: (tag: string | null) => void;
 }
 
+/**
+ * 左サイドバー。固定カテゴリ一覧とトレンドタグによる絞り込み UI を提供する。
+ * 同じカテゴリ/タグを再クリックすると選択解除（`null`）としてトグルする。
+ * デザインテーマの引用文パネルも表示する。中〜大画面（md 以上）でのみ表示する。
+ */
 const Sidebar: React.FC<SidebarProps> = ({
   theme,
   tags,
@@ -24,8 +36,11 @@ const Sidebar: React.FC<SidebarProps> = ({
 }) => {
   const { colors, fontHeader, sidebarStyle, borderRadius } = theme;
 
+  // 表示用ラベル: 先頭の `#` を除去し前後空白を落とす（`#` は CSS の before で付与するため）
   const normalizeTag = (tag: string) => tag.replace(/^#/, '').trim();
+  // 比較・選択判定用の値: 大文字小文字を無視するため小文字化する
   const normalizeTagValue = (tag: string) => normalizeTag(tag).toLowerCase();
+  // 正規化後の表示ラベルで重複排除し、ラベル（表示用）と value（判定用）の組へ整形する
   const visibleTags = Array.from(
     new Set(tags.map(normalizeTag).filter(Boolean)),
   ).map((tag) => ({

--- a/front/src/components/pages/DetailPage.tsx
+++ b/front/src/components/pages/DetailPage.tsx
@@ -10,20 +10,31 @@ import ConfirmationModal from '@/components/organisms/ConfirmationModal';
 import ReportMarkdown from '@/components/organisms/ReportMarkdown';
 
 interface DetailPageProps {
+  /** テーマ（配色・フォント・角丸などのデザイントークン一式） */
   theme: DesignSystem;
+  /** 表示対象のレポート。未取得／存在しない場合は undefined */
   report?: ReportItem;
+  /** ログイン中ユーザー。null の場合は未ログイン（編集・削除ボタンを出さない） */
   user: User | null;
+  /** 削除実行ハンドラ。成否を MutationResult で返す（呼び出し側が API を担う） */
   onDelete: (id: string) => Promise<MutationResult>;
 }
 
+/**
+ * レポート詳細画面。本文（Markdown）・外部URL・タグを表示する。
+ * ログイン済みユーザーにのみ編集・削除の導線を出す認証ガードを持ち、
+ * 削除確認モーダルからの削除実行と結果ハンドリングを担う。
+ */
 const DetailPage: React.FC<DetailPageProps> = ({ theme, report, user, onDelete }) => {
   const router = useRouter();
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [deleteError, setDeleteError] = useState<string | null>(null);
   const { colors, fontHeader, fontPrimary, borderRadius } = theme;
+  // publishDate を優先し、無ければ createdAt を使い、ISO の日付部分のみ表示する。
   const displayDate = report
     ? (report.publishDate || report.createdAt || '').split('T')[0]
     : '';
+  // 著者名はログイン中ユーザー名に統一（未ログイン時は 'Manager'）。単一管理者運用のため。
   const displayAuthor = user?.username ?? 'Manager';
 
   if (!report) {
@@ -128,6 +139,7 @@ const DetailPage: React.FC<DetailPageProps> = ({ theme, report, user, onDelete }
           setDeleteError(null);
           const result = await onDelete(report.id);
           if (!result.ok) {
+            // 認証切れ・権限不足はログイン画面へ誘導。それ以外はその場でエラー表示する。
             if (result.status === 401 || result.status === 403) {
               router.push('/login');
             } else {

--- a/front/src/components/pages/FormPage.tsx
+++ b/front/src/components/pages/FormPage.tsx
@@ -9,14 +9,25 @@ import ExternalUrlFieldList from '@/components/molecules/ExternalUrlFieldList';
 import ConfirmationModal from '@/components/organisms/ConfirmationModal';
 
 interface FormPageProps {
+  /** テーマ（配色・フォント・角丸などのデザイントークン一式） */
   theme: DesignSystem;
+  /** 既存レポート群。編集時に reportId から初期値を引き当てるために使う */
   reports?: ReportItem[];
+  /** 送信ハンドラ（新規作成／更新）。成否を MutationResult で返す */
   onSubmit: (data: Omit<ReportItem, 'id'>) => Promise<MutationResult>;
+  /** ログイン中ユーザー。フォームのロジック（権限・著者情報）に利用する */
   user: User | null;
+  /** 編集対象のレポートID。未指定なら新規投稿モードとして扱う */
   reportId?: string;
+  /** ハイドレーション完了フラグ。未完了時は描画を抑止してSSR不一致を避ける */
   isHydrated?: boolean;
 }
 
+/**
+ * レポートの新規投稿・編集フォーム画面。reportId の有無で新規／編集モードを
+ * 切り替える。入力・バリデーション・外部URLの増減・送信確認モーダルといった
+ * フォームロジックは useReportForm フックに委譲し、本コンポーネントは描画に専念する。
+ */
 const FormPage: React.FC<FormPageProps> = ({
   theme,
   reports,
@@ -44,6 +55,8 @@ const FormPage: React.FC<FormPageProps> = ({
     goBack,
   } = useReportForm({ user, reportId, reports, onSubmit, isHydrated });
 
+  // ハイドレーション未完了の間は描画しない（クライアント専用の初期値でSSRとの
+  // マークアップ不一致が起きるのを避けるため）。
   if (!isHydrated) return null;
 
   const fieldLabelClass = colors.muted;

--- a/front/src/components/pages/ListPage.tsx
+++ b/front/src/components/pages/ListPage.tsx
@@ -11,19 +11,34 @@ import PaginationNav from '@/components/molecules/PaginationNav';
 import { DesignSystem, ReportItem } from '@/types';
 
 interface ListPageProps {
+  /** テーマ（配色・フォント・角丸などのデザイントークン一式） */
   theme: DesignSystem;
+  /** 一覧表示するレポート群（サーバー側で取得済みのものを受け取る） */
   reports: ReportItem[];
 }
 
+/**
+ * レポート一覧画面。サーバーから受け取ったレポートを、カテゴリ／タグの
+ * 選択状態でフィルタし、ページネーションして表示する。
+ * 各カードから詳細ページ（`/report/:id`）へ遷移する。
+ */
 const ListPage: React.FC<ListPageProps> = ({ theme, reports }) => {
   const { colors, fontHeader, fontPrimary, borderRadius } = theme;
   const { selectedCategory, selectedTag, setSelectedCategory, setSelectedTag, currentUser } = useAppState();
 
+  // 一覧画面に入るたびに前回のフィルタ選択を解除し、常に全件表示から始める。
+  // （サイドバー等でのフィルタ状態はグローバルに持続するため、ここでリセットする）
   useEffect(() => {
     setSelectedCategory(null);
     setSelectedTag(null);
   }, [setSelectedCategory, setSelectedTag]);
 
+  /**
+   * タグ文字列を比較用に正規化する。先頭の `#` を除去し、前後空白を落とし、
+   * 小文字化することで、表記ゆれ（`#UI` / `ui` 等）を吸収して照合する。
+   *
+   * @param tag - 正規化対象のタグ文字列
+   */
   const normalizeTagValue = (tag: string) => tag.replace(/^#/, '').trim().toLowerCase();
   const visibleReports = reports.filter((report) => {
     if (selectedCategory && report.category !== selectedCategory) return false;
@@ -34,11 +49,19 @@ const ListPage: React.FC<ListPageProps> = ({ theme, reports }) => {
     return true;
   });
 
+  // フィルタ条件が変わったらページネーションを1ページ目へ戻すためのキー。
+  // このキーの変化を usePagination が検知して現在ページをリセットする。
   const filterKey = `${selectedCategory ?? ''}|${selectedTag ?? ''}`;
   const { currentPage, totalPages, pageNumbers, updatePage, paginateSlice } =
     usePagination(visibleReports.length, filterKey);
   const paginatedReports = paginateSlice(visibleReports);
 
+  /**
+   * カード表示用の日付を求める。publishDate を優先し、無ければ createdAt に
+   * フォールバックする。ISO 形式（`T` 区切り）の場合は日付部分のみを取り出す。
+   *
+   * @param report - 日付を取り出す対象レポート
+   */
   const getDisplayDate = (report: ReportItem) => {
     const raw = report.publishDate || report.createdAt || '';
     return raw.includes('T') ? raw.split('T')[0] : raw;
@@ -64,6 +87,8 @@ const ListPage: React.FC<ListPageProps> = ({ theme, reports }) => {
 
       <div className="grid gap-8 grid-cols-1 lg:grid-cols-2">
         {paginatedReports.map((report) => {
+          // 著者名はレポート個別の値ではなく、ログイン中ユーザー名（未ログイン時は
+          // 'Manager'）に統一して表示する。運用上、投稿者は単一の管理者を前提とするため。
           const displayAuthor = currentUser?.username ?? 'Manager';
           return (
             <article

--- a/front/src/components/pages/LoginPage.tsx
+++ b/front/src/components/pages/LoginPage.tsx
@@ -5,11 +5,18 @@ import LoginForm from '@/components/organisms/LoginForm';
 import { DesignSystem } from '@/types';
 
 interface LoginPageProps {
+  /** テーマ（配色・フォント・角丸などのデザイントークン一式） */
   theme: DesignSystem;
+  /** メール／パスワードでのログイン処理。失敗時はエラーメッセージ、成功時は null を返す */
   onLogin: (email: string, password: string) => Promise<string | null>;
+  /** Google OAuth でのログイン処理。失敗時はエラーメッセージ、成功時は null を返す */
   onLoginWithGoogle: () => Promise<string | null>;
 }
 
+/**
+ * ログイン画面。実体の入力フォーム・送信処理は LoginForm 組織体に委譲する薄い
+ * ページラッパー。テーマとログインハンドラをそのまま受け渡す。
+ */
 const LoginPage: React.FC<LoginPageProps> = ({ theme, onLogin, onLoginWithGoogle }) => {
   return <LoginForm theme={theme} onLogin={onLogin} onLoginWithGoogle={onLoginWithGoogle} />;
 };

--- a/front/src/components/pages/MarkdownLabPage.tsx
+++ b/front/src/components/pages/MarkdownLabPage.tsx
@@ -6,15 +6,19 @@ import { DesignSystem } from '@/types';
 import ReportMarkdown from '@/components/organisms/ReportMarkdown';
 
 interface MarkdownLabPageProps {
+  /** テーマ（配色・フォント・角丸などのデザイントークン一式） */
   theme: DesignSystem;
 }
 
+/** Markdown 表示スタイルの現行採用パターン。ラボ画面のヘッダー表示に使う。 */
 const ACTIVE_VARIANT = {
   id: 'v7',
   label: 'Pattern 07 - Code Focus',
   note: 'Selected baseline. Code contrast, quote emphasis, and URL visibility are tuned in this pattern.',
 } as const;
 
+// スタイル比較用の固定サンプル Markdown。見出し・リスト・引用・コード・表・
+// mermaid・画像など、表示調整で確認したい要素を一通り含めている。
 const MARKDOWN_SAMPLE = [
   '# Quarter Strategy Snapshot',
   '',
@@ -79,6 +83,11 @@ const MARKDOWN_SAMPLE = [
   '![Local sample image](/next.svg)',
 ].join('\n');
 
+/**
+ * Markdown スタイル検証用のラボ画面。固定サンプル（MARKDOWN_SAMPLE）を
+ * 現行採用パターンで ReportMarkdown により描画し、配色・間隔・可読性を
+ * 目視で確認するための開発向けページ。
+ */
 const MarkdownLabPage: React.FC<MarkdownLabPageProps> = ({ theme }) => {
   const { colors, fontHeader, borderRadius } = theme;
 

--- a/front/src/hooks/useLoginForm.ts
+++ b/front/src/hooks/useLoginForm.ts
@@ -1,7 +1,10 @@
 import { useState } from 'react';
 
+/** `useLoginForm` の依存注入。認証処理本体は AppState 側の関数を渡す。 */
 interface UseLoginFormOptions {
+  /** メール/パスワードでのログイン。成功時 null、失敗時エラーメッセージを返す。 */
   onLogin: (email: string, password: string) => Promise<string | null>;
+  /** Google OAuth でのログイン。成功時 null、失敗時エラーメッセージを返す。 */
   onLoginWithGoogle: () => Promise<string | null>;
 }
 
@@ -16,24 +19,35 @@ const initialErrorFromUrl = (): string | null => {
   return errorParam === 'unauthorized' ? '許可されていないメールアドレスです。' : null;
 };
 
+/**
+ * ログインフォームの状態と送信ハンドラを管理するフック。
+ *
+ * 入力値・エラー・送信中フラグを保持する。送信成功時は画面遷移が起きるため
+ * `isSubmitting` はあえて解除せず、失敗時（メッセージあり）のみ false に戻して再入力を許す。
+ *
+ * @returns 入力値・setter・`error`・`isSubmitting`・送信/Googleログインの各ハンドラ
+ */
 export const useLoginForm = ({ onLogin, onLoginWithGoogle }: UseLoginFormOptions) => {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState<string | null>(initialErrorFromUrl);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
+  // メール/パスワード送信。未入力なら何もしない。
   const handleSubmit = (event: React.FormEvent) => {
     event.preventDefault();
     if (!email || !password) return;
     setIsSubmitting(true);
     void onLogin(email, password).then((message) => {
       setError(message);
+      // 成功時は遷移するため解除しない。失敗時のみ再入力できるよう解除する。
       if (message) {
         setIsSubmitting(false);
       }
     });
   };
 
+  // Google OAuth 送信。リダイレクトが走るため成功時は解除しない。
   const handleGoogleLogin = () => {
     setIsSubmitting(true);
     void onLoginWithGoogle().then((message) => {

--- a/front/src/hooks/usePagination.ts
+++ b/front/src/hooks/usePagination.ts
@@ -1,10 +1,26 @@
 import { useState } from 'react';
 
+/** ページング挙動の調整オプション。 */
 interface UsePaginationOptions {
+  /** 1 ページあたりの件数（既定 10）。 */
   itemsPerPage?: number;
+  /** 表示するページ番号ボタンの最大数（既定 5）。 */
   maxPageButtons?: number;
 }
 
+/**
+ * 一覧のページング状態を管理するフック。
+ *
+ * `filterKey` が現在の状態と異なる場合は自動的に 1 ページ目へ戻す。これにより
+ * 「カテゴリ/タグのフィルタを変えたらページを 1 に戻す」挙動を、明示的なリセット呼び出しなしで実現する
+ * （state に `page` と一緒に `filterKey` を持たせ、レンダー時に比較する）。
+ * `currentPage` は総ページ数でクランプするため、件数が減っても範囲外にならない。
+ *
+ * @param totalItems 全アイテム数（総ページ数の算出に使う）
+ * @param filterKey 現在のフィルタを表す文字列。変化すると 1 ページ目へリセットする
+ * @param options 1 ページ件数・ページ番号ボタン数の上書き
+ * @returns `currentPage`・`totalPages`・表示用 `pageNumbers`・`updatePage`・`paginateSlice`
+ */
 export const usePagination = (
   totalItems: number,
   filterKey: string,
@@ -17,10 +33,13 @@ export const usePagination = (
   }));
 
   const totalPages = Math.ceil(totalItems / itemsPerPage);
+  // 0 件でも 1 ページ扱いにして、ページ番号や範囲計算が破綻しないようにする。
   const safeTotalPages = Math.max(1, totalPages);
+  // filterKey が変わっていれば 1 ページ目に戻す。同じなら保存中のページを上限でクランプする。
   const currentPage =
     paginationState.filterKey === filterKey ? Math.min(paginationState.page, safeTotalPages) : 1;
 
+  // 現在ページを中央に寄せつつ、先頭/末尾でボタン列が範囲外へはみ出さないよう始点を決める。
   const pageStart = Math.max(
     1,
     Math.min(currentPage - Math.floor(maxPageButtons / 2), safeTotalPages - maxPageButtons + 1),
@@ -28,6 +47,11 @@ export const usePagination = (
   const pageEnd = Math.min(safeTotalPages, pageStart + maxPageButtons - 1);
   const pageNumbers = Array.from({ length: pageEnd - pageStart + 1 }, (_, index) => pageStart + index);
 
+  /**
+   * 表示ページを更新する。範囲外の値は [1, 総ページ数] にクランプする。
+   *
+   * @param nextPage 遷移先ページ番号
+   */
   const updatePage = (nextPage: number) => {
     setPaginationState({
       page: Math.min(Math.max(nextPage, 1), safeTotalPages),
@@ -35,6 +59,12 @@ export const usePagination = (
     });
   };
 
+  /**
+   * 配列から現在ページ分だけを切り出す。
+   *
+   * @param items ページングしたい全アイテム配列
+   * @returns 現在ページに対応する要素のみを含む配列
+   */
   const paginateSlice = <T,>(items: T[]): T[] => {
     return items.slice((currentPage - 1) * itemsPerPage, currentPage * itemsPerPage);
   };

--- a/front/src/hooks/useReport.ts
+++ b/front/src/hooks/useReport.ts
@@ -2,9 +2,10 @@ import { useEffect, useState } from 'react';
 import { ReportItem } from '@/types';
 
 /**
- * Fetches a single report with full content from /api/reports/[id].
- * Returns the cached report from the list (without content) immediately,
- * then replaces it with the full report once the API responds.
+ * 単一レポートを本文込みで `/api/reports/[id]` から取得するフック。
+ *
+ * 一覧由来の本文なしキャッシュ（`listReport`）を即座に表示し、API 応答後に全文へ差し替える
+ * ことで、詳細画面の初期表示を待たせない。local モードや既に本文を持つ場合は fetch を省く。
  *
  * @param reportId - 取得対象レポートの ID（未定義なら fetch しない）
  * @param listReport - 一覧から渡る本文なしのキャッシュ。即時表示の初期値に使う
@@ -25,20 +26,19 @@ export const useReport = (
   useEffect(() => {
     if (!reportId) return;
 
-    // In local mode, the list already has full content
+    // local モードは一覧が既に本文を持つため、そのまま使う。
     if (dataMode === 'local') {
       setReport(listReport);
       return;
     }
 
-    // If list report already has content (optimistic update after create/edit),
-    // use it directly without fetching
+    // 作成/編集直後の楽観更新などで本文を既に持っていれば、fetch せずそのまま使う。
     if (listReport?.content) {
       setReport(listReport);
       return;
     }
 
-    // Show list metadata immediately while fetching full content
+    // 全文取得の間、一覧のメタ情報を先に表示しておく。
     if (listReport) {
       setReport(listReport);
     }

--- a/front/src/hooks/useReportForm.ts
+++ b/front/src/hooks/useReportForm.ts
@@ -3,14 +3,29 @@ import { useRouter } from 'next/navigation';
 import { ExternalUrlInput, MutationResult, ReportItem, User } from '@/types';
 import { CATEGORIES } from '@/constants';
 
+/** `useReportForm` の入力。新規作成と編集の両方を 1 つのフックで扱う。 */
 interface UseReportFormOptions {
+  /** ログイン中ユーザー。未ログインなら初期化時にログイン画面へ退避する。 */
   user: User | null;
+  /** 編集対象レポートの ID。未指定なら新規作成モード。 */
   reportId?: string;
+  /** 既存レポート一覧。編集時に `reportId` から初期値を引く。 */
   reports?: ReportItem[];
+  /** 送信処理本体（作成 or 更新）。AppState 側の関数を渡す。 */
   onSubmit: (data: Omit<ReportItem, 'id'>) => Promise<MutationResult>;
+  /** 初期化完了フラグ。false の間は未ログイン退避・初期値投入を保留する。 */
   isHydrated?: boolean;
 }
 
+/**
+ * レポート作成/編集フォームの状態・バリデーション・送信を管理するフック。
+ *
+ * 編集時は `reports` から既存値をフォームに流し込み、未ログイン時はログイン画面へ退避する
+ * （いずれも `isHydrated` 完了後に実行し、初期化前の誤判定を避ける）。
+ * 送信は確認モーダルを挟む二段構え（`handleSubmitAttempt` → `handleConfirmSubmit`）。
+ *
+ * @returns フォーム値・各種エラー・外部URL操作・確認モーダル制御・各ハンドラ
+ */
 export const useReportForm = ({
   user,
   reportId,
@@ -67,6 +82,7 @@ export const useReportForm = ({
     }
   }, [reportId, reports, user, router, isHydrated]);
 
+  // 汎用フィールドの変更ハンドラ。入力があった項目のサーバーエラーはその場でクリアする。
   const handleChange = (
     event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>,
   ) => {
@@ -81,6 +97,7 @@ export const useReportForm = ({
     }
   };
 
+  // タグ入力（カンマ区切り）を `#` 付き canonical form に正規化して反映する。
   const handleTagsChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const tags = event.target.value
       .split(',')
@@ -101,6 +118,7 @@ export const useReportForm = ({
     }
   };
 
+  // 送信前チェック（タグ必須）。通過したら確認モーダルを開く。実送信は handleConfirmSubmit。
   const handleSubmitAttempt = (event: React.FormEvent) => {
     event.preventDefault();
     if (formData.tags.length === 0) {
@@ -110,9 +128,19 @@ export const useReportForm = ({
     setShowConfirmModal(true);
   };
 
+  // 空の外部URL入力行を 1 つ追加する。
   const addExternalUrl = () =>
     setExternalUrls((prev) => [...prev, { url: '', label: '' }]);
 
+  /**
+   * 指定インデックスの外部URL行を削除する。
+   *
+   * 行を消すと後続行のインデックスが 1 つずつ前へ詰まるため、`externalUrls.{i}.{field}` 形式の
+   * フィールドエラーキーも同じ規則で貼り替える（削除行のエラーは破棄、後続は index-1 に再割当）。
+   * これをしないとエラー表示が別の行にずれてしまう。
+   *
+   * @param index 削除対象行のインデックス
+   */
   const removeExternalUrl = (index: number) => {
     setExternalUrls((prev) => prev.filter((_, i) => i !== index));
     setFieldErrors((prev) => {
@@ -132,6 +160,13 @@ export const useReportForm = ({
     });
   };
 
+  /**
+   * 外部URL行の url / label を更新し、その行の該当エラーをクリアする。
+   *
+   * @param index 対象行のインデックス
+   * @param field 更新するフィールド（`url` または `label`）
+   * @param value 新しい値
+   */
   const updateExternalUrl = (index: number, field: 'url' | 'label', value: string) => {
     setExternalUrls((prev) => prev.map((eu, i) => (i === index ? { ...eu, [field]: value } : eu)));
     const errorKey = `externalUrls.${index}.${field}`;
@@ -144,6 +179,13 @@ export const useReportForm = ({
     }
   };
 
+  /**
+   * 確認モーダルで確定後の実送信。
+   *
+   * 外部URLをクライアント側で先行検証し（url/label のいずれかが入力された行のみ対象）、
+   * 問題があれば送信せずフィールドエラーを表示する。送信後は結果に応じて分岐する:
+   * 401/403 はログイン画面へ、`fieldErrors` があれば各項目に、それ以外は全体エラーに反映する。
+   */
   const handleConfirmSubmit = async () => {
     setServerError(null);
     setFieldErrors({});
@@ -151,6 +193,7 @@ export const useReportForm = ({
     externalUrls.forEach((eu, i) => {
       const trimmedUrl = eu.url.trim();
       const trimmedLabel = eu.label.trim();
+      // url も label も空の行は「未入力」として検証・送信の対象外にする。
       const hasInput = trimmedUrl || trimmedLabel;
       if (!hasInput) return;
       if (!trimmedUrl) {
@@ -167,6 +210,7 @@ export const useReportForm = ({
       return;
     }
 
+    // url が入力された行だけを送信対象にする（空行は送らない）。
     const activeUrls = externalUrls
       .filter((eu) => eu.url.trim())
       .map((eu) => ({ url: eu.url.trim(), label: eu.label.trim() }));

--- a/front/src/lib/auth-server.ts
+++ b/front/src/lib/auth-server.ts
@@ -1,16 +1,32 @@
+// 書き込み系 API の管理者ゲート。Route Handler から `requireAdmin()` を呼び、
+// Bearer トークンを Supabase で検証したうえで `ADMIN_EMAIL` 許可リストと照合する。
+// RLS と合わせた二重防御の「アプリ側」を担う（`.claude/rules/security.md`）。
+
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
 
+/** 認可結果。成功時は管理者メール、失敗時は返すべき HTTP レスポンスを含む。 */
 type RequireAdminResult = { ok: true; email: string } | { ok: false; response: NextResponse };
 
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL ?? '';
 const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? '';
+// サーバー側でトークン検証に使う Supabase クライアント（モジュールスコープで 1 度だけ生成）。
 const supabaseAdmin = createClient(supabaseUrl, supabaseAnonKey);
 
-// Cache verified tokens in memory (survives across warm invocations)
+// 検証済みトークンをメモリにキャッシュする（ウォーム起動をまたいで生存する）。
+// 同一トークンの 2 回目以降は Supabase への HTTP 往復を省き、レイテンシを削減する。
 const authCache = new Map<string, { email: string; expiresAt: number }>();
-const AUTH_CACHE_TTL = 5 * 60 * 1000; // 5 minutes
+const AUTH_CACHE_TTL = 5 * 60 * 1000; // 5 分
 
+/**
+ * ログ出力用にメールを部分マスクする。
+ *
+ * ログにメールアドレス（センシティブ情報）を平文で残さないための措置
+ * （`.claude/rules/error-handling.md`）。先頭 1 文字とドメインのみ残す。
+ *
+ * @param value マスク対象のメールアドレス
+ * @returns `a***@example.com` 形式のマスク文字列。空や短すぎる場合は `''` / `'***'`
+ */
 const maskEmail = (value: string) => {
   if (!value) return '';
   const at = value.indexOf('@');
@@ -18,6 +34,18 @@ const maskEmail = (value: string) => {
   return `${value[0]}***@${value.slice(at + 1)}`;
 };
 
+/**
+ * リクエストが管理者によるものかを検証する認可ガード。
+ *
+ * `Authorization: Bearer <token>` を取り出し、キャッシュヒット時はそれで即判定、
+ * 未ヒット時は Supabase でトークンを検証してメールを取得し、`ADMIN_EMAIL`（カンマ区切り）と照合する。
+ * 認証失敗・トークン欠落・非管理者はそれぞれ 401/403 のレスポンスを `response` に載せて返す
+ * （呼び出し側はそのまま return できる）。
+ *
+ * @param request 検証対象のリクエスト（Authorization ヘッダを参照）
+ * @param context ログに付与する呼び出し元識別子（例: エンドポイント名）
+ * @returns 成功時は `{ ok: true, email }`、失敗時は `{ ok: false, response }`
+ */
 export const requireAdmin = async (
   request: NextRequest,
   context: string,
@@ -35,7 +63,7 @@ export const requireAdmin = async (
     .map((e) => e.trim().toLowerCase())
     .filter(Boolean);
 
-  // Check in-memory cache first (skip Supabase HTTP round-trip)
+  // まずメモリキャッシュを確認する（Supabase への HTTP 往復を省く）。
   const cached = authCache.get(token);
   if (cached && cached.expiresAt > Date.now()) {
     if (adminEmails.includes(cached.email.toLowerCase())) {
@@ -57,10 +85,10 @@ export const requireAdmin = async (
     return { ok: false, response: NextResponse.json({ error: 'Forbidden' }, { status: 403 }) };
   }
 
-  // Cache successful verification
+  // 検証成功をキャッシュする。
   authCache.set(token, { email, expiresAt: Date.now() + AUTH_CACHE_TTL });
 
-  // Evict expired entries to prevent memory leak
+  // メモリリーク防止のため、一定サイズを超えたら期限切れエントリを掃除する。
   if (authCache.size > 100) {
     const now = Date.now();
     for (const [key, val] of authCache) {

--- a/front/src/lib/db.ts
+++ b/front/src/lib/db.ts
@@ -1,11 +1,26 @@
+// Prisma Client のシングルトン。全 API ルートはこのインスタンスを共有する。
+//
+// globalThis にキャッシュして再利用するのが肝:
+//   - 開発時: Next.js のホットリロードでモジュールが再評価されるたびに新しい接続が生まれ、
+//     Postgres の接続数が枯渇するのを防ぐ。
+//   - 本番時: サーバーレスのウォーム起動間でインスタンスを使い回し、コールドスタート時の
+//     DB 再接続コストを削減する（`.claude/rules/database.md` の方針）。
+
 import { PrismaClient } from '@prisma/client';
 
+/** グローバルに Prisma シングルトンを退避するための型拡張。 */
 type GlobalWithPrisma = typeof globalThis & {
   prisma?: PrismaClient;
 };
 
 const globalForPrisma = globalThis as GlobalWithPrisma;
 
+/**
+ * アプリ全体で共有する Prisma Client。
+ *
+ * 既にグローバルへ格納済みならそれを再利用し、無ければ生成する。
+ * ログは `error` のみに絞り、正常クエリのノイズを出さない。
+ */
 export const prisma =
   globalForPrisma.prisma ??
   new PrismaClient({

--- a/front/src/lib/openapi/document.ts
+++ b/front/src/lib/openapi/document.ts
@@ -25,10 +25,23 @@ const isAllowedRequestSchema = z
 const isAllowedSchema = z.object({ allowed: z.boolean() }).meta({ id: 'IsAllowedResponse' });
 const okSchema = z.object({ ok: z.boolean() }).meta({ id: 'OkResponse' });
 
+/**
+ * `application/json` のリクエストボディ定義を組み立てる短縮ヘルパー。
+ *
+ * @param schema ボディの zod スキーマ
+ * @returns OpenAPI の requestBody 用オブジェクト
+ */
 const jsonBody = <T extends z.ZodType>(schema: T) => ({
   content: { 'application/json': { schema } },
 });
 
+/**
+ * `application/json` のレスポンス定義を組み立てる短縮ヘルパー。
+ *
+ * @param description レスポンスの説明
+ * @param schema レスポンスボディの zod スキーマ
+ * @returns OpenAPI の response 用オブジェクト
+ */
 const jsonResponse = <T extends z.ZodType>(description: string, schema: T) => ({
   description,
   content: { 'application/json': { schema } },
@@ -43,8 +56,18 @@ const reportListQuery = z.object({
   offset: z.string().optional().meta({ description: 'スキップ件数（0〜）', example: '0' }),
 });
 
+/** 生成する OpenAPI ドキュメントの仕様バージョン。 */
 export const OPENAPI_VERSION = '3.1.0';
 
+/**
+ * 全エンドポイントを含む OpenAPI ドキュメントを組み立てる。
+ *
+ * パス定義とスキーマ参照をまとめ、`createDocument` で OpenAPI 3.1 ドキュメントを返す。
+ * `scripts/gen-openapi.ts`（`docs/openapi.json` 生成）と `/api/openapi`（Swagger UI 用）から呼ばれる。
+ *
+ * @param version `info.version` に載せる API バージョン（既定 `'0.0.0'`）
+ * @returns 生成された OpenAPI ドキュメントオブジェクト
+ */
 export const buildOpenApiDocument = (version = '0.0.0') =>
   createDocument({
     openapi: OPENAPI_VERSION,

--- a/front/src/lib/schemas/report.ts
+++ b/front/src/lib/schemas/report.ts
@@ -15,6 +15,7 @@ import { CATEGORIES } from '@/constants';
  * `z.preprocess` で内側に取り込み、サーバーの後方互換を保つ。
  */
 
+/** 各フィールドの文字数・件数の上限。エラーメッセージにも埋め込む単一ソース。 */
 export const LIMITS = {
   title: 200,
   summary: 500,
@@ -217,6 +218,7 @@ export const reportPatchSchema = z
 
 // --- レスポンススキーマ ---
 
+/** 外部 URL 1 件（レスポンス）。id 付きで label は null 許容。 */
 export const externalUrlItemSchema = z
   .object({
     id: z.string().meta({ example: 'eu_123' }),
@@ -225,6 +227,7 @@ export const externalUrlItemSchema = z
   })
   .meta({ id: 'ExternalUrlItem' });
 
+/** レポート 1 件（レスポンス）。一覧 API では `content` は空文字で返る。 */
 export const reportItemSchema = z
   .object({
     id: z.string().meta({ example: 'rep_123' }),
@@ -241,6 +244,7 @@ export const reportItemSchema = z
   })
   .meta({ id: 'ReportItem' });
 
+/** タグ名の配列（レスポンス）。 */
 export const tagListSchema = z.array(z.string()).meta({ id: 'TagList', example: ['#AI', '#Cloud'] });
 
 /** バリデーションエラーレスポンス（フィールド名 → 日本語メッセージ）。 */
@@ -253,6 +257,9 @@ export const errorSchema = z
   .object({ error: z.string() })
   .meta({ id: 'ErrorResponse', example: { error: 'Not found' } });
 
+/** レポート新規作成リクエストの推論型。 */
 export type ReportCreateInput = z.infer<typeof reportCreateSchema>;
+/** レポート更新（部分）リクエストの推論型。 */
 export type ReportPatchInput = z.infer<typeof reportPatchSchema>;
+/** レポート 1 件（レスポンス）の推論型。 */
 export type ReportItemOutput = z.infer<typeof reportItemSchema>;

--- a/front/src/lib/supabaseClient.ts
+++ b/front/src/lib/supabaseClient.ts
@@ -1,10 +1,18 @@
+// クライアント（ブラウザ）側の Supabase シングルトン。
+// anon key のみを使い、認証セッション管理（getSession / signInWithOAuth 等）に用いる。
+// サーバー側の管理者判定は別モジュール（`auth-server.ts`）が担う。
+
 import { createClient } from '@supabase/supabase-js';
 
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL ?? '';
 const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? '';
 
+// env 未設定でも import 時に throw せず警告に留める。
+// CI/ビルドはダミー値で動かす方針（`.claude/rules/environment.md`）のため、
+// 実行時まで失敗を遅延させて開発体験を損なわないようにする。
 if (!supabaseUrl || !supabaseAnonKey) {
   console.warn('Supabase env vars are missing. Check NEXT_PUBLIC_SUPABASE_URL/ANON_KEY.');
 }
 
+/** ブラウザ用 Supabase クライアント（anon key・認証セッション用のシングルトン）。 */
 export const supabase = createClient(supabaseUrl, supabaseAnonKey);

--- a/front/src/lib/validation.ts
+++ b/front/src/lib/validation.ts
@@ -14,6 +14,7 @@ import {
  * これにより Route Handler とフロントのエラー契約を変更せずに済む。
  */
 
+/** フィールド名 → 日本語エラーメッセージ。エラーの無いフィールドはキーごと省略する。 */
 export type ValidationErrors = {
   title?: string;
   content?: string;
@@ -23,6 +24,7 @@ export type ValidationErrors = {
   summary?: string;
 };
 
+/** 検証モード切替。`partial: true` で部分更新（PATCH）スキーマを使う。 */
 type ValidateOptions = {
   partial?: boolean;
 };
@@ -61,6 +63,16 @@ const toFieldErrors = (issues: { path: PropertyKey[]; message: string }[]): Vali
   return errors;
 };
 
+/**
+ * レポート本文フィールド（title/content/category/author/tags/summary/publishDate）を検証・正規化する。
+ *
+ * `externalUrls` はここでは扱わず `validateExternalUrls` が担当する。
+ * 成功時は正規化済みの `data` と空の `errors`、失敗時は空の `data` と `errors`（先勝ち）を返す。
+ *
+ * @param input 検証対象の生入力（unknown。zod 側で寛容に正規化する）
+ * @param options `partial: true` で部分更新スキーマを使う（未指定フィールドを許容）
+ * @returns 正規化済みデータとフィールド別エラーの組
+ */
 export const validateReportInput = (
   input: unknown,
   options: ValidateOptions = {},
@@ -84,6 +96,16 @@ export const validateReportInput = (
 
 const URL_PATTERN = /^https?:\/\//;
 
+/**
+ * 外部URL配列を検証・正規化する。
+ *
+ * URL は必須かつ `http(s)://` 始まり、label は任意で最大長チェック。
+ * エラーキーは `externalUrls.{index}.url` / `externalUrls.{index}.label` の形で、
+ * フロントが該当行にエラーを紐付けられるようにする。未指定（undefined/null）は空データとして許容する。
+ *
+ * @param urls 検証対象（配列でなければ全体エラーを返す）
+ * @returns トリム済みの `data` とインデックス付きの `errors`
+ */
 export const validateExternalUrls = (
   urls: unknown,
 ): { data: ExternalUrlInput[]; errors: Record<string, string> } => {

--- a/front/src/providers/AppStateProvider.tsx
+++ b/front/src/providers/AppStateProvider.tsx
@@ -1,31 +1,76 @@
 'use client';
 
+// アプリ全体の状態（認証ユーザー・レポート一覧・タグ・フィルタ選択）を一元管理する
+// 中枢プロバイダー。BFF（`/api/*`）越しのデータ取得・CRUD と Supabase Auth をここに集約する。
+//
+// このファイル全体を貫く重要な設計軸が「2 つの動作モード」:
+//   - supabase モード（本番・既定）: 認証は Supabase Auth、データは BFF（Prisma 経由）
+//   - local   モード（E2E 専用）  : 認証もデータも localStorage で完結（実 DB / OAuth を使わない）
+// `authMode` / `dataMode`（環境変数）で分岐し、各関数が両モードの実装を内包する。
+// 詳細は `.claude/rules/environment.md`・`docs/06-security-specification.md` を参照。
+
 import React, { createContext, useContext, useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { AUTH_COOKIE_NAME, ESPRESSO_THEME } from '@/constants';
 import { DesignSystem, MutationResult, ReportItem, User } from '@/types';
 import { supabase } from '@/lib/supabaseClient';
 
+/**
+ * アプリ横断の状態と操作を公開するコンテキストの形。
+ *
+ * 状態（読み取り）とミューテーション（書き込み操作）を 1 つの値にまとめ、
+ * 配下コンポーネントが `useAppState()` 経由で参照する。
+ */
 interface AppState {
+  /** 配色・スタイル定義（現状は固定テーマ）。 */
   theme: DesignSystem;
+  /** 表示中のレポート一覧。一覧 API では content を除外した軽量版が入る。 */
   reports: ReportItem[];
+  /** サイドバーのフィルタ候補となるタグ一覧（reports から派生）。 */
   tags: string[];
+  /** サイドバーで選択中のカテゴリ。未選択は null。 */
   selectedCategory: string | null;
+  /** カテゴリ選択を更新する（同一値の再クリックで null に戻す運用は呼び出し側で行う）。 */
   setSelectedCategory: (category: string | null) => void;
+  /** サイドバーで選択中のタグ。未選択は null。 */
   selectedTag: string | null;
+  /** タグ選択を更新する。 */
   setSelectedTag: (tag: string | null) => void;
+  /** ログイン中の管理者。未ログインは null。 */
   currentUser: User | null;
+  /** 初期化（データ取得 + 認証復元）が完了したか。false の間はローディング表示に使う。 */
   isHydrated: boolean;
+  /**
+   * メール/パスワードでログインする。
+   * @returns 成功時は null、失敗時はエラーメッセージ
+   */
   login: (email: string, password: string) => Promise<string | null>;
+  /**
+   * Google OAuth でログインする（supabase モードのみ有効）。
+   * @returns 成功時は null、失敗時はエラーメッセージ
+   */
   loginWithGoogle: () => Promise<string | null>;
+  /** ログアウトしてログイン画面へ遷移する。 */
   logout: () => Promise<void>;
+  /** レポートを新規作成する。 */
   addReport: (report: Omit<ReportItem, 'id'>) => Promise<MutationResult>;
+  /** レポートを部分更新する。 */
   updateReport: (id: string, updatedData: Partial<ReportItem>) => Promise<MutationResult>;
+  /** レポートを削除する。 */
   deleteReport: (id: string) => Promise<MutationResult>;
 }
 
 const AppStateContext = createContext<AppState | undefined>(undefined);
 
+/**
+ * アプリ状態コンテキストを取得するフック。
+ *
+ * プロバイダー外での誤用を早期検知するため、未提供時は例外を投げる
+ * （no-op フォールバックを返すと状態不整合が黙って進行するため、あえて fail-fast）。
+ *
+ * @returns アプリ横断の状態と操作
+ * @throws {Error} `AppStateProvider` の外で呼ばれた場合
+ */
 export const useAppState = () => {
   const context = useContext(AppStateContext);
   if (!context) {
@@ -34,6 +79,12 @@ export const useAppState = () => {
   return context;
 };
 
+/**
+ * アプリ全体の状態・認証・CRUD を提供するプロバイダー。
+ *
+ * マウント時に「レポート/タグ取得」と「認証セッション復元」を並行実行し、
+ * 完了後に `isHydrated` を true にする。supabase モードでは認証状態変化も購読する。
+ */
 export const AppStateProvider = ({ children }: { children: React.ReactNode }) => {
   const [reports, setReports] = useState<ReportItem[]>([]);
   const [tags, setTags] = useState<string[]>([]);
@@ -48,6 +99,15 @@ export const AppStateProvider = ({ children }: { children: React.ReactNode }) =>
   const dataMode = process.env.NEXT_PUBLIC_DATA_MODE ?? 'supabase';
   const siteUrl = process.env.NEXT_PUBLIC_SITE_URL;
 
+  /**
+   * ミドルウェア等のサーバー側が認証状態を判定するための目印 Cookie を張り替える。
+   *
+   * 認証の実体は Bearer トークン（CSRF 対策で Cookie に置かない方針）だが、
+   * サーバーはリクエスト時にトークンを持たないため、遷移制御用の非機密フラグのみ Cookie に持たせる。
+   * 認証時は 7 日（604800 秒）で発行し、未認証時は Max-Age=0 で即時失効させる。
+   *
+   * @param isAuthenticated 認証済みなら true（フラグ発行）、未認証なら false（フラグ削除）
+   */
   const setAuthFlagCookie = (isAuthenticated: boolean) => {
     if (typeof document === 'undefined') return;
     if (isAuthenticated) {
@@ -57,6 +117,17 @@ export const AppStateProvider = ({ children }: { children: React.ReactNode }) =>
     document.cookie = `${AUTH_COOKIE_NAME}=; Path=/; Max-Age=0; SameSite=Lax`;
   };
 
+  /**
+   * ログインしようとしているメールが管理者許可リストに含まれるかをサーバーで照合する。
+   *
+   * 判定ロジックはモードで分岐する:
+   *   - local   : メールを body で送り `/api/auth/is-allowed`（POST）で照合
+   *   - supabase: Bearer トークンを送り `/api/auth/admin`（GET）で照合（メールを露出させない）
+   * `ADMIN_EMAIL` はサーバー専用のため判定は必ず API 越しに行う（クライアントに秘匿値を出さない）。
+   * 通信失敗時は安全側に倒して不許可（false）を返す。
+   *
+   * @returns 許可メールなら true、非許可・トークン欠落・通信失敗なら false
+   */
   const checkAllowedEmail = async ({
     email,
     accessToken: token,
@@ -90,9 +161,25 @@ export const AppStateProvider = ({ children }: { children: React.ReactNode }) =>
     }
   };
 
+  /**
+   * レポート群から重複を除いたタグ一覧を導出する。
+   *
+   * タグ用 API を別途叩かず reports から派生させることで、mutation 後の余計な再取得を避け、
+   * サイドバー表示と一覧データの整合を常に保つ（`fetchTags` 廃止に伴う一元化）。
+   *
+   * @param items タグを収集する対象のレポート配列
+   * @returns 空値を除いたユニークなタグ配列
+   */
   const deriveTagsFromReports = (items: ReportItem[]) =>
     Array.from(new Set(items.flatMap((report) => report.tags ?? []).filter(Boolean)));
 
+  /**
+   * レポート一覧を取得して状態に反映する。
+   *
+   * local モードは localStorage から復元（`externalUrls` 欠落を空配列で補正）、
+   * supabase モードは BFF（`/api/reports`）から取得する。いずれも失敗時は空配列にフォールバックし、
+   * 描画側が undefined を踏まないようにする。
+   */
   const fetchReports = async () => {
     if (dataMode === 'local') {
       const savedReports = localStorage.getItem('espresso_reports');
@@ -131,6 +218,13 @@ export const AppStateProvider = ({ children }: { children: React.ReactNode }) =>
     }
   };
 
+  /**
+   * サイドバー用のタグ一覧を取得して状態に反映する。
+   *
+   * 初期化時のみ使用する。local モードは localStorage から派生、supabase モードは
+   * `/api/tags`（ReportTag テーブル由来）から取得する。mutation 後の更新は API を叩かず
+   * `deriveTagsFromReports` で reports から導出する（不要な API 呼び出しを避けるため）。
+   */
   const fetchTags = async () => {
     if (dataMode === 'local') {
       const savedReports = localStorage.getItem('espresso_reports');
@@ -163,7 +257,9 @@ export const AppStateProvider = ({ children }: { children: React.ReactNode }) =>
     }
   };
 
+  // マウント時の初期化: データ取得と認証復元を並行実行し、完了後に isHydrated を立てる。
   useEffect(() => {
+    // 保存済みセッション/ユーザーを復元し、許可メールでなければサインアウトさせる。
     const initAuth = async () => {
       if (authMode === 'local') {
         const savedUser = localStorage.getItem('espresso_user');
@@ -237,6 +333,8 @@ export const AppStateProvider = ({ children }: { children: React.ReactNode }) =>
     }
   }, [reports, dataMode]);
 
+  // local モードのみ currentUser を localStorage に永続化する。
+  // isHydrated 前は初期 null で保存済みユーザーを上書きしてしまうため、初期化完了までスキップする。
   useEffect(() => {
     if (authMode === 'local') {
       if (!isHydrated) return;
@@ -244,11 +342,14 @@ export const AppStateProvider = ({ children }: { children: React.ReactNode }) =>
     }
   }, [currentUser, authMode, isHydrated]);
 
+  // 認証状態が変わるたびサーバー判定用のフラグ Cookie を同期する（初期化完了後のみ）。
   useEffect(() => {
     if (!isHydrated) return;
     setAuthFlagCookie(Boolean(currentUser));
   }, [currentUser, isHydrated]);
 
+  // supabase モードでの認証状態変化（OAuth リダイレクト後のサインインやトークン更新等）を購読し、
+  // 許可メールの再検証つきで currentUser / accessToken を同期する。
   useEffect(() => {
     if (authMode === 'local') return;
     const { data: subscription } = supabase.auth.onAuthStateChange((_event, session) => {
@@ -284,6 +385,16 @@ export const AppStateProvider = ({ children }: { children: React.ReactNode }) =>
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  /**
+   * メール/パスワードでログインする。
+   *
+   * どちらのモードでも「許可メール照合」を通過した場合のみログインを確定する。
+   * 非許可なら supabase モードでは即サインアウトし、エラーメッセージを返す（画面側で表示）。
+   *
+   * @param email 入力メールアドレス
+   * @param password 入力パスワード（local モードでは未使用のダミー扱い）
+   * @returns 成功時は null、失敗時はユーザー向けエラーメッセージ
+   */
   const login = async (email: string, password: string) => {
     if (authMode === 'local') {
       const user = { id: '1', username: 'Manager', email, role: 'admin' as const };
@@ -325,6 +436,16 @@ export const AppStateProvider = ({ children }: { children: React.ReactNode }) =>
     return null;
   };
 
+  /**
+   * Google OAuth でログインする。
+   *
+   * local モードでは OAuth を使わないため何もせず null を返す。supabase モードでは
+   * リダイレクト先を `NEXT_PUBLIC_SITE_URL` 優先で決め、無ければ実行時の origin にフォールバックする
+   * （本番のリダイレクト URL 固定と、ローカル/プレビューでの動作を両立させるため）。
+   * 実際の許可メール検証は、リダイレクト後に発火する onAuthStateChange 側で行う。
+   *
+   * @returns 成功時は null、OAuth 開始に失敗した場合はエラーメッセージ
+   */
   const loginWithGoogle = async () => {
     if (authMode === 'local') {
       return null;
@@ -340,6 +461,12 @@ export const AppStateProvider = ({ children }: { children: React.ReactNode }) =>
     return null;
   };
 
+  /**
+   * ログアウトしてログイン画面へ遷移する。
+   *
+   * ローカル状態（currentUser / accessToken）とフラグ Cookie をクリアし、
+   * supabase モードでは Supabase 側セッションも破棄する。
+   */
   const logout = async () => {
     console.info('[auth] logout');
     if (authMode === 'local') {
@@ -357,6 +484,16 @@ export const AppStateProvider = ({ children }: { children: React.ReactNode }) =>
     router.push('/login');
   };
 
+  /**
+   * レポートを新規作成し、成功時は一覧の先頭に反映して一覧画面へ遷移する。
+   *
+   * local モードはクライアント側で ID を採番して localStorage に追加、supabase モードは
+   * Bearer トークン付きで `/api/reports`（POST）へ送る。楽観更新はせず、API 応答（作成済みレコード）で
+   * 状態を更新し、タグは reports から再導出する。
+   *
+   * @param report id を除いたレポート入力値
+   * @returns 成功可否・エラー内容を表す MutationResult（フィールド別バリデーションエラーを含みうる）
+   */
   const addReport = async (report: Omit<ReportItem, 'id'>): Promise<MutationResult> => {
     if (dataMode === 'local') {
       const newReport = {
@@ -413,6 +550,16 @@ export const AppStateProvider = ({ children }: { children: React.ReactNode }) =>
     }
   };
 
+  /**
+   * レポートを部分更新し、成功時は該当詳細画面へ遷移する。
+   *
+   * local モードは外部URLに欠落 ID を補ってから localStorage を書き換え、supabase モードは
+   * Bearer トークン付きで `/api/reports/{id}`（PATCH）へ送り、応答レコードで状態を置き換える。
+   *
+   * @param id 更新対象レポートの ID
+   * @param updatedData 変更したいフィールドのみを含む部分オブジェクト
+   * @returns 成功可否・エラー内容を表す MutationResult
+   */
   const updateReport = async (
     id: string,
     updatedData: Partial<ReportItem>,
@@ -475,6 +622,15 @@ export const AppStateProvider = ({ children }: { children: React.ReactNode }) =>
     }
   };
 
+  /**
+   * レポートを削除し、成功時は一覧から除いて一覧画面へ遷移する。
+   *
+   * local モードは localStorage から除外、supabase モードは Bearer トークン付きで
+   * `/api/reports/{id}`（DELETE）へ送る。削除後はタグを reports から再導出する。
+   *
+   * @param id 削除対象レポートの ID
+   * @returns 成功可否・エラー内容を表す MutationResult
+   */
   const deleteReport = async (id: string): Promise<MutationResult> => {
     if (dataMode === 'local') {
       console.info('[reports] delete', { reportId: id });

--- a/front/src/providers/LoadingContext.tsx
+++ b/front/src/providers/LoadingContext.tsx
@@ -1,13 +1,26 @@
 'use client';
 
+// 画面遷移時に表示するグローバルなローディングオーバーレイを、
+// 任意のコンポーネントから起動できるようにする軽量コンテキスト。
+// 実際の表示状態やタイマー制御は AppShell 側（`startLoading` の実体）が持ち、
+// ここは「起動の合図を伝搬する」導管に徹する。
+
 import React, { createContext, useContext } from 'react';
 
+/** ローディング開始トリガーのみを公開する最小のコンテキスト値。 */
 type LoadingContextValue = {
+  /** グローバルローディング表示を開始する。 */
   startLoading: () => void;
 };
 
 const LoadingContext = createContext<LoadingContextValue | null>(null);
 
+/**
+ * `startLoading` を配下ツリーへ供給するプロバイダー。
+ *
+ * 表示ロジック本体を持たず、上位（AppShell）から渡された `value` をそのまま流すだけの
+ * 薄いラッパー。ローディング制御の実装を差し替えても子側のインターフェースを保てる。
+ */
 export const LoadingProvider = ({
   value,
   children,
@@ -15,6 +28,15 @@ export const LoadingProvider = ({
   value: LoadingContextValue;
 }>) => <LoadingContext.Provider value={value}>{children}</LoadingContext.Provider>;
 
+/**
+ * ローディング開始関数を取得するフック。
+ *
+ * プロバイダー外で呼ばれても壊れないよう、その場合は no-op の `startLoading` を返す。
+ * これにより「ローディング制御が不要／未提供な文脈でも安全に呼べる」ことを保証する
+ * （例: プロバイダーで包まれないテストや単独レンダリング時に例外を投げない）。
+ *
+ * @returns ローディング開始関数を持つオブジェクト。プロバイダー外では no-op を返す
+ */
 export const useLoading = () => {
   const context = useContext(LoadingContext);
   return context ?? { startLoading: () => {} };


### PR DESCRIPTION
## 概要

`front/src/` の主要領域（providers / lib / hooks / components / app）の公開シンボルに JSDoc を付与し、非自明な処理に「なぜ」を残すコメントを追加した。**コードのロジックは一切変更しておらず、コメント/JSDoc の追加のみ**（英語コメントの日本語化を含む）。

プロジェクトの JSDoc 規約（`.claude/rules/jsdoc.md`）に準拠:
- 型は JSDoc に書かない（TS シグネチャが唯一の真実）。意図・意味・制約を日本語で記述
- props 型は各プロパティに説明を付与
- `as unknown` 等の回避策・ドメインロジック・早期 return など「コードから根拠が消える箇所」に why を明記
- `.ts`（フック/lib/API）は `@param`/`@returns` を規約どおり付与、`.tsx` は `@returns` を付けない

## 主な変更

- **providers/**: `AppStateProvider`（2モード設計・認証/CRUD）、`LoadingContext` の役割と why
- **lib/**: `db.ts`（Prisma シングルトンのグローバル再利用理由）、`auth-server.ts`（認可ガード・メールマスク・認証キャッシュ）、`validation.ts` / `schemas` / `openapi` の公開シンボル
- **hooks/**: `usePagination`（filterKey による1ページ目リセットの仕組み）、`useReportForm`（外部URLエラーキー再割当）等
- **components/**: atoms〜pages 34ファイルの要約 JSDoc・props 各プロパティ説明。特に `ReportMarkdown` の見出し分類・サニタイズ必須の why
- **app/**: API ルート 6件（認可・ステータス・キャッシュ方針）、page/layout/client の server/client 役割

## テストメモ

- `pnpm lint`（`eslint-plugin-jsdoc` の `require-param`/`require-returns` 含む）: パス
- `pnpm typecheck`（`tsc --noEmit`）: パス
- `git diff` で非コメント行の削除が0件であることを機械確認済み（ロジック不変の担保）

## ドキュメント影響

JSDoc/コメント付与のみで API 契約・仕様・スキーマの変更はないため、`docs/` 影響マップ該当なし（更新不要）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)