### PR TITLE
Add Makefile wrapping front/ pnpm scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,101 @@
+# Makefile — front/ の pnpm スクリプトを root から実行するためのラッパー。
+# 全コマンドは front/ ディレクトリで pnpm 実行する（CLAUDE.md の規約に準拠）。
+# 使い方: `make <target>`（引数なしの `make` はヘルプを表示）。
+
+FRONT := front
+PNPM  := pnpm
+
+.DEFAULT_GOAL := help
+
+.PHONY: help install dev build start \
+        lint typecheck format check \
+        test test-watch test-integration test-e2e test-e2e-ui test-e2e-report \
+        gen-openapi gen-test-schema \
+        prisma-pull prisma-generate
+
+## ヘルプを表示
+help:
+	@grep -E '^## ' -A1 $(MAKEFILE_LIST) \
+		| grep -vE '^--' \
+		| awk '/^## / { desc=substr($$0, 4); next } { split($$1, a, ":"); printf "  \033[36m%-18s\033[0m %s\n", a[1], desc }'
+
+# --- セットアップ / 開発 -----------------------------------------------------
+
+## 依存をインストール（postinstall で prisma generate 実行）
+install:
+	cd $(FRONT) && $(PNPM) install
+
+## 開発サーバー起動（http://localhost:3000）
+dev:
+	cd $(FRONT) && $(PNPM) dev
+
+## プロダクションビルド
+build:
+	cd $(FRONT) && $(PNPM) build
+
+## プロダクションビルドを配信
+start:
+	cd $(FRONT) && $(PNPM) start
+
+# --- 静的解析 / 整形 ---------------------------------------------------------
+
+## ESLint 実行（CI のグリーン条件）
+lint:
+	cd $(FRONT) && $(PNPM) lint
+
+## 型チェック（tsc --noEmit）
+typecheck:
+	cd $(FRONT) && $(PNPM) typecheck
+
+## Prettier で整形
+format:
+	cd $(FRONT) && $(PNPM) format
+
+## lint + typecheck をまとめて実行（CI static-analysis 相当）
+check: lint typecheck
+
+# --- テスト -----------------------------------------------------------------
+
+## ユニットテスト（Vitest）
+test:
+	cd $(FRONT) && $(PNPM) test
+
+## ユニットテスト（watch モード）
+test-watch:
+	cd $(FRONT) && $(PNPM) test:watch
+
+## 統合テスト（Testcontainers Postgres・Docker 必須）
+test-integration:
+	cd $(FRONT) && $(PNPM) test:integration
+
+## E2E テスト（Playwright）
+test-e2e:
+	cd $(FRONT) && $(PNPM) test:e2e
+
+## E2E テスト（UI モード）
+test-e2e-ui:
+	cd $(FRONT) && $(PNPM) test:e2e:ui
+
+## E2E テストレポート表示
+test-e2e-report:
+	cd $(FRONT) && $(PNPM) test:e2e:report
+
+# --- 生成物 -----------------------------------------------------------------
+
+## OpenAPI ドキュメント生成（docs/openapi.json）
+gen-openapi:
+	cd $(FRONT) && $(PNPM) gen:openapi
+
+## IT 用 DDL 生成（tests/integration/schema.sql）
+gen-test-schema:
+	cd $(FRONT) && $(PNPM) gen:test-schema
+
+# --- Prisma -----------------------------------------------------------------
+
+## 既存 DB スキーマを取得（マイグレーションは禁止）
+prisma-pull:
+	cd $(FRONT) && $(PNPM) prisma db pull
+
+## Prisma Client を再生成
+prisma-generate:
+	cd $(FRONT) && $(PNPM) prisma generate

--- a/front/README.md
+++ b/front/README.md
@@ -115,6 +115,8 @@ pnpm build    # 本番ビルド
 pnpm start    # ビルド成果物を配信
 ```
 
+> リポジトリ root から `make dev` / `make build` / `make test` などでも実行できます（`front/` の pnpm scripts を委譲するラッパー）。一覧は root で `make` を実行。
+
 ## 動作モード（local / supabase）
 
 このアプリは認証・データ取得をそれぞれ2モードで切り替えます。環境変数 `NEXT_PUBLIC_AUTH_MODE` / `NEXT_PUBLIC_DATA_MODE` で制御し、**未設定なら supabase モード**になります。


### PR DESCRIPTION
## 概要

root に `Makefile` を追加した。**何を**: `front/` の `package.json` scripts を root から実行できるラッパー。**なぜ**: 全コマンドを `front/` で `pnpm` 実行する構成のため、毎回 `cd front` する手間を Makefile に閉じ込め、コマンド体系を一箇所で見渡せるようにするため。

- 全ターゲットは `cd front && pnpm ...` に委譲（「front/ で実行」という規約を人間が覚えなくて済む）
- 引数なし `make` はヘルプ（ターゲット一覧）を表示 — 破壊的操作をデフォルトにしない
- pnpm のコロン記法（`test:e2e`）は make ターゲットに使えないためハイフン（`test-e2e`）へ変換
- `check` = `lint` + `typecheck`（CI の static-analysis 相当）
- `prisma migrate` は**あえて含めない**（`.claude/rules/database.md` の migrate 禁止に準拠。`prisma-pull` / `prisma-generate` のみ）

## テストメモ

- `make`（= `make help`）でターゲット一覧が整列表示されることを確認
- Makefile は pnpm scripts の薄いラッパーで、既存の挙動・依存を一切変更しない

## ドキュメント影響

影響マップ該当なしと判断。Makefile は新規コマンドを定義するものではなく既存 `package.json` scripts のラッパーであり、正準は引き続き `.claude/rules/commands.md` / `package.json`。乖離を生む変更ではないため docs 更新は不要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)