### PR TITLE
docs(rules): .claude/rules/ の記載漏れを補う（IT・typecheck・frontmatter）

### DIFF
--- a/.claude/rules/commands.md
+++ b/.claude/rules/commands.md
@@ -15,8 +15,18 @@ pnpm dev       # 開発サーバー起動（http://localhost:3000）
 pnpm build     # プロダクションビルド
 pnpm start     # プロダクションビルド配信
 pnpm lint      # ESLint 実行（CI のグリーン条件 / git-workflow.md 参照）
+pnpm typecheck # tsc --noEmit（CI 必須。ビルドは型を検査しないため別途実行する / typescript.md 参照）
 pnpm format    # Prettier 整形
 ```
+
+## コード生成
+
+```bash
+pnpm gen:openapi      # lib/schemas/（zod）から docs/openapi.json を生成（api.md 参照）
+pnpm gen:test-schema  # IT 用の schema.sql を生成（database.md の test-only 例外）
+```
+
+- スキーマ・検証ルールを変更したら `pnpm gen:openapi` を実行し、生成物をコミットする。
 
 ## テスト
 

--- a/.claude/rules/github-issue.md
+++ b/.claude/rules/github-issue.md
@@ -1,3 +1,8 @@
+---
+description: GitHub issue 運用（ブランチと対で issue を作成し open/close で進捗管理）
+globs: 
+---
+
 # GitHub issue 運用
 
 開発の作業単位を GitHub issue で管理する。

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -6,7 +6,7 @@ globs:
 # テスト方針
 
 - テストは**正常/準正常/異常**をすべて必須とする。
-- ユニットテストとE2Eテストの両方でカバーする。
+- ユニットテスト（UT）・統合テスト（IT）・E2E テストの 3 レベルでカバーする。
 - E2Eは `NEXT_PUBLIC_AUTH_MODE=local` / `NEXT_PUBLIC_DATA_MODE=local` で動作させる。
 
 ## テストツール
@@ -14,19 +14,25 @@ globs:
 | テスト種別 | ツール |
 |-----------|--------|
 | ユニットテスト | Vitest + @testing-library/react |
+| 統合テスト（IT） | Vitest + Testcontainers（Postgres）。**Docker 必須** |
 | E2E テスト | Playwright |
+
+- IT は **API ルート × 実 DB** を対象とし、モックしない。詳細な方針（`globalSetup` で 1 度だけコンテナ起動、テスト間 `TRUNCATE`、RLS はスコープ外）は `docs/08-test-specification.md` を参照する。
+- IT が使うスキーマ DDL は `pnpm gen:test-schema` で生成する（`database.md` の test-only 例外）。
 
 ## ディレクトリ配置
 
 - ユニットテスト: `front/src/<module>/__tests__/` に配置する
+- 統合テスト: `front/tests/integration/` に配置する
 - E2Eテスト: `front/tests/e2e/` に配置する
 
 ## 実行コマンド（`front/` ディレクトリで実行）
 
 ```bash
-pnpm test            # ユニットテスト実行
-pnpm test:watch      # ユニットテスト（watchモード）
-pnpm test:e2e        # E2Eテスト実行
-pnpm test:e2e:ui     # UIモード
-pnpm test:e2e:report # レポート表示
+pnpm test             # ユニットテスト実行
+pnpm test:watch       # ユニットテスト（watchモード）
+pnpm test:integration # 統合テスト実行（Docker 必須）
+pnpm test:e2e         # E2Eテスト実行
+pnpm test:e2e:ui      # UIモード
+pnpm test:e2e:report  # レポート表示
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,13 +50,13 @@ Markdownレポートの保存・閲覧UIを提供するNext.jsアプリ。
 |---|---|---|
 | `coding-standards.md` | 全体 | コーディング規約（TypeScript/pnpm/ESLint/Prettier） |
 | `documentation.md` | 全体 | ドキュメント更新・設計書管理ルール（影響マップ + opt-out の完了条件） |
-| `commands.md` | 全体 | Build & Dev コマンド（pnpm dev / build / format 等） |
+| `commands.md` | 全体 | Build & Dev コマンド（pnpm dev / build / typecheck / format / gen:* 等） |
 | `environment.md` | 全体 | 環境変数一覧・管理方針 |
 | `error-handling.md` | 全体 | エラーハンドリング方針（バリデーション・ログ・HTTPステータス） |
 | `git-workflow.md` | 全体 | ブランチ・コミット・PR 規約 |
 | `github-issue.md` | 全体 | GitHub issue 駆動開発（ブランチと対で起票・open/close で進捗管理・PR で自動クローズ） |
 | `security.md` | 全体 | セキュリティ設計方針（認証・RLS・XSS対策・シークレット管理） |
-| `testing.md` | 全体 | テスト方針・コマンド・配置規約（Vitest + Playwright） |
+| `testing.md` | 全体 | テスト方針・コマンド・配置規約（UT: Vitest / IT: Vitest + Testcontainers / E2E: Playwright） |
 | `duplication.md` | 全体 | 重複と共通化の判断基準（同じ知識のみ共通化・3回目で共通化・`common`/`util` を置き場にしない） |
 | `dead-code.md` | 全体 | デッドコード禁止（コメントアウト・未使用 export・旧実装・スキップ放置テストを残さない） |
 | `static-analysis.md` | 全体 | 静的解析の運用（Formatter と Linter の役割分担・CI 必須・警告ゼロ・抑制コメントは理由と最小範囲） |

--- a/docs/11-tasks.md
+++ b/docs/11-tasks.md
@@ -216,6 +216,7 @@
 - [x] docs index を youtube-my-collection の構成・文体を参考に再構成（`docs/README.md` / 2026-06-10）
 - [x] docs/ 全仕様書（01〜11・README）にアンカーリンク付き目次を追加（h3まで・形式統一 / 2026-06-10）
 - [x] root/front README の役割分担と重複解消（技術スタック・開発手順を front に集約 / PR #75 / 2026-06-12）
+- [x] `rules-update` スキルのテンプレートと `.claude/rules/` を全文突合し、記載漏れ 3 件を補完（`testing.md` に IT / `commands.md` に typecheck・gen:* / `github-issue.md` の frontmatter / Issue #149 / 2026-07-26）
 
 ## API / バリデーション基盤
 


### PR DESCRIPTION
## 概要

`rules-update` スキルのテンプレートと `.claude/rules/` 18 ファイルを全文突合し、**ルールの記載が実態（`package.json` / CI / `docs/`）に追随できていなかった 3 件**を補完する。

生成物そのものに過不足は無く、テンプレとの差分の大半は意図した翻訳（`security.md` の Supabase Auth 化、`database.md` の migrate 禁止への反転、`typescript.md` の単一 `types.ts` 集約など）であることも確認済み。本 PR はその突合で残った記載漏れのみを扱う。

| ファイル | 変更 | 乖離していた根拠 |
|---|---|---|
| `.claude/rules/testing.md` | UT/IT/E2E の 3 レベルに更新。ツール表に Testcontainers、配置に `front/tests/integration/`、コマンドに `pnpm test:integration` を追加 | `docs/08-test-specification.md` L91〜98・`.github/workflows/test.yml:94`・`package.json` は IT 前提なのに、ルールには記載が無かった |
| `.claude/rules/commands.md` | `pnpm typecheck` を追加。「コード生成」節を新設し `gen:openapi` / `gen:test-schema` を記載 | `typescript.md` が `tsc --noEmit` を CI 必須と規定し `test.yml:62` でも実行しているが、コマンド一覧に無かった |
| `.claude/rules/github-issue.md` | frontmatter（`description` / `globs`）を追加 | 18 ファイル中このファイルのみ欠落しており、テンプレとも他ファイルの体裁とも不揃いだった |
| `CLAUDE.md` | Rules テーブルの `testing.md` / `commands.md` 行の説明を更新 | 上記変更との同期（Step 5 相当） |
| `docs/11-tasks.md` | ドキュメント節に完了エントリを追加 | `documentation.md` の影響マップ |

IT の詳細方針（`globalSetup` での 1 度きりのコンテナ起動・テスト間 `TRUNCATE`・RLS スコープ外）は `testing.md` に写さず、正準である `docs/08-test-specification.md` への参照に留めた（`duplication.md`「同じ知識を 2 箇所に置かない」）。

## テストメモ

- `markdownlint-cli2` を全 35 ファイルに実行 → **0 issues**。
- **アプリコードの変更は無いため lint / test / build / デプロイは非該当**（`github-actions.md`「ドキュメント・ルールのみの変更でテスト・デプロイを回さない」）。`docs.yml` の軽量チェックのみが対象。

## ドキュメント更新（documentation.md の完了条件）

- 影響マップ「`.claude/rules/` ルールの追加・削除・説明変更」→ `CLAUDE.md` の Rules テーブルを更新済み。
- 影響マップ「E2E / ユニットテストケースの追加・変更」→ **該当なし**。テストケース自体は変更しておらず、既存の `docs/08-test-specification.md` の IT 記述にルール側を合わせただけのため、08 の更新は不要。

## スクリーンショット

UI 変更なしのため無し。

Closes #149
