### PR TITLE
fix: 認証ログにメールアドレスを出力しない

### DIFF
--- a/front/src/providers/AppStateProvider.tsx
+++ b/front/src/providers/AppStateProvider.tsx
@@ -422,7 +422,8 @@ export const AppStateProvider = ({ children }: { children: React.ReactNode }) =>
         await supabase.auth.signOut();
         return '許可されていないメールアドレスです。';
       }
-      console.info('[auth] login', { userId: sessionUser.id, username: sessionUser.email });
+      // メールアドレスは個人情報のためログに出さない（error-handling.md）。追跡は userId で足りる
+      console.info('[auth] login', { userId: sessionUser.id });
       setCurrentUser({
         id: sessionUser.id,
         username: 'Manager',


### PR DESCRIPTION
## 概要

`.claude/rules/error-handling.md`「センシティブ情報（メールアドレス・トークン等）はログに含めない」に違反していた 1 箇所を修正する。

`front/src/providers/AppStateProvider.tsx:425` が `username` というキー名でメールアドレスをそのまま `console.info` に出力しており、Vercel のランタイムログに個人情報が残っていた。`userId` のみに変更し、なぜ出さないのかをコメントで残した。

```diff
-console.info('[auth] login', { userId: sessionUser.id, username: sessionUser.email });
+// メールアドレスは個人情報のためログに出さない（error-handling.md）。追跡は userId で足りる
+console.info('[auth] login', { userId: sessionUser.id });
```

`local` モード側（同 405 行）の `username` は固定文字列 `'Manager'` であり個人情報ではないため変更していない。

## テストメモ

- `grep -rn "console." front/src | grep -iE "email|token|password"` → 残るのは `is-allowed/route.ts` の 2 件のみで、いずれも**値を含まない**メッセージのみ（`missing supabase env` / `failed to verify access token`）。
- `pnpm typecheck` ✅ / `pnpm lint` ✅ / `pnpm test` ✅ 110 tests passed

## ドキュメント更新

影響マップ上、該当なし。ログ方針は `error-handling.md` に既に記載済みで、本 PR はその規定に実装を合わせるもの。

## スクリーンショット

UI 変更なしのため無し。

Closes #143