### PR TITLE
refactor: カスタムフックの戻り値型を明示する

### DIFF
--- a/front/src/hooks/useLoginForm.ts
+++ b/front/src/hooks/useLoginForm.ts
@@ -19,15 +19,38 @@ const initialErrorFromUrl = (): string | null => {
   return errorParam === 'unauthorized' ? '許可されていないメールアドレスです。' : null;
 };
 
+/** ログインフォームの状態と操作。 */
+type UseLoginFormResult = {
+  /** メール入力値。 */
+  email: string;
+  /** メール入力値を更新する。 */
+  setEmail: (email: string) => void;
+  /** パスワード入力値。 */
+  password: string;
+  /** パスワード入力値を更新する。 */
+  setPassword: (password: string) => void;
+  /** 表示中のエラーメッセージ。`null` はエラーなし。初期値は URL の `?error=unauthorized` 由来 */
+  error: string | null;
+  /** 送信中フラグ。**成功時は遷移するため解除されない**（失敗時のみ false に戻る） */
+  isSubmitting: boolean;
+  /** メール/パスワードで送信する。未入力の場合は何もしない */
+  handleSubmit: (event: React.FormEvent) => void;
+  /** Google OAuth を開始する。リダイレクトが走るため成功時は戻ってこない */
+  handleGoogleLogin: () => void;
+};
+
 /**
  * ログインフォームの状態と送信ハンドラを管理するフック。
  *
  * 入力値・エラー・送信中フラグを保持する。送信成功時は画面遷移が起きるため
  * `isSubmitting` はあえて解除せず、失敗時（メッセージあり）のみ false に戻して再入力を許す。
  *
- * @returns 入力値・setter・`error`・`isSubmitting`・送信/Googleログインの各ハンドラ
+ * @returns フォームの状態と各ハンドラ
  */
-export const useLoginForm = ({ onLogin, onLoginWithGoogle }: UseLoginFormOptions) => {
+export const useLoginForm = ({
+  onLogin,
+  onLoginWithGoogle,
+}: UseLoginFormOptions): UseLoginFormResult => {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState<string | null>(initialErrorFromUrl);

--- a/front/src/hooks/usePagination.ts
+++ b/front/src/hooks/usePagination.ts
@@ -8,6 +8,20 @@ interface UsePaginationOptions {
   maxPageButtons?: number;
 }
 
+/** ページング状態と、それを操作する関数。 */
+type UsePaginationResult = {
+  /** 表示中のページ番号（1 始まり）。総ページ数でクランプ済みのため範囲外にならない */
+  currentPage: number;
+  /** 総ページ数。0 件でも 1 を返す（ページ番号の計算を破綻させないため） */
+  totalPages: number;
+  /** ページ番号ボタンとして表示する番号の並び。現在ページを中央に寄せ、最大 `maxPageButtons` 件 */
+  pageNumbers: number[];
+  /** 表示ページを変更する。範囲外の値は [1, 総ページ数] にクランプされる */
+  updatePage: (nextPage: number) => void;
+  /** 全件配列から現在ページ分だけを切り出す。API の再取得は伴わない（クライアント側ページング） */
+  paginateSlice: <T>(items: T[]) => T[];
+};
+
 /**
  * 一覧のページング状態を管理するフック。
  *
@@ -19,13 +33,13 @@ interface UsePaginationOptions {
  * @param totalItems 全アイテム数（総ページ数の算出に使う）
  * @param filterKey 現在のフィルタを表す文字列。変化すると 1 ページ目へリセットする
  * @param options 1 ページ件数・ページ番号ボタン数の上書き
- * @returns `currentPage`・`totalPages`・表示用 `pageNumbers`・`updatePage`・`paginateSlice`
+ * @returns ページング状態と操作関数
  */
 export const usePagination = (
   totalItems: number,
   filterKey: string,
   options: UsePaginationOptions = {},
-) => {
+): UsePaginationResult => {
   const { itemsPerPage = 10, maxPageButtons = 5 } = options;
   const [paginationState, setPaginationState] = useState(() => ({
     page: 1,

--- a/front/src/hooks/useReport.ts
+++ b/front/src/hooks/useReport.ts
@@ -1,6 +1,14 @@
 import { useEffect, useState } from 'react';
 import { ReportItem } from '@/types';
 
+/** レポート詳細の取得結果。 */
+type UseReportResult = {
+  /** 表示対象のレポート。未取得・取得失敗時は `undefined`（「該当なし」ではない） */
+  report: ReportItem | undefined;
+  /** 本文の取得中のみ true。一覧キャッシュを表示中や local モードでは false のまま */
+  isLoading: boolean;
+};
+
 /**
  * 単一レポートを本文込みで `/api/reports/[id]` から取得するフック。
  *
@@ -9,12 +17,12 @@ import { ReportItem } from '@/types';
  *
  * @param reportId - 取得対象レポートの ID（未定義なら fetch しない）
  * @param listReport - 一覧から渡る本文なしのキャッシュ。即時表示の初期値に使う
- * @returns 現在のレポート（`report`）と取得中フラグ（`isLoading`）
+ * @returns レポートと取得中フラグ
  */
 export const useReport = (
   reportId: string | undefined,
   listReport: ReportItem | undefined,
-) => {
+): UseReportResult => {
   const [report, setReport] = useState<ReportItem | undefined>(listReport);
   const [isLoading, setIsLoading] = useState(false);
 

--- a/front/src/hooks/useReportForm.ts
+++ b/front/src/hooks/useReportForm.ts
@@ -17,6 +17,42 @@ interface UseReportFormOptions {
   isHydrated?: boolean;
 }
 
+/** レポートフォームの状態と操作。 */
+type UseReportFormResult = {
+  /** フォームの入力値。編集時は `reports` から引いた既存値で初期化される */
+  formData: Omit<ReportItem, 'id'>;
+  /** タグ未入力エラー。`null` はエラーなし */
+  tagError: string | null;
+  /** サーバー起因のエラーメッセージ。`null` はエラーなし */
+  serverError: string | null;
+  /** 項目別エラー。キーはフィールド名、外部URLは `externalUrls.{index}.{url|label}` 形式 */
+  fieldErrors: Record<string, string>;
+  /** 外部URL入力行。`url` が空の行は送信対象から除外される */
+  externalUrls: ExternalUrlInput[];
+  /** 送信確認モーダルの開閉状態。 */
+  showConfirmModal: boolean;
+  /** 送信確認モーダルの開閉を切り替える。 */
+  setShowConfirmModal: (show: boolean) => void;
+  /** 汎用フィールドの変更を反映する。該当項目のエラーはその場でクリアされる */
+  handleChange: (
+    event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>,
+  ) => void;
+  /** タグ入力（カンマ区切り）を `#` 付き canonical form に正規化して反映する。 */
+  handleTagsChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  /** 送信前チェックを行い、通れば確認モーダルを開く。この時点では API を呼ばない */
+  handleSubmitAttempt: (event: React.FormEvent) => void;
+  /** 実際に送信する。失敗時は認証エラーなら `/login` へ、それ以外はエラー状態に反映する */
+  handleConfirmSubmit: () => Promise<void>;
+  /** 空の外部URL入力行を 1 行追加する。 */
+  addExternalUrl: () => void;
+  /** 指定行を削除する。後続行のフィールドエラーキーも index を詰めて貼り替える */
+  removeExternalUrl: (index: number) => void;
+  /** 指定行の `url` または `label` を更新する。 */
+  updateExternalUrl: (index: number, field: 'url' | 'label', value: string) => void;
+  /** 直前の画面へ戻る。保存は行わない */
+  goBack: () => void;
+};
+
 /**
  * レポート作成/編集フォームの状態・バリデーション・送信を管理するフック。
  *
@@ -24,7 +60,7 @@ interface UseReportFormOptions {
  * （いずれも `isHydrated` 完了後に実行し、初期化前の誤判定を避ける）。
  * 送信は確認モーダルを挟む二段構え（`handleSubmitAttempt` → `handleConfirmSubmit`）。
  *
- * @returns フォーム値・各種エラー・外部URL操作・確認モーダル制御・各ハンドラ
+ * @returns フォームの状態と各ハンドラ
  */
 export const useReportForm = ({
   user,
@@ -32,7 +68,7 @@ export const useReportForm = ({
   reports,
   onSubmit,
   isHydrated = true,
-}: UseReportFormOptions) => {
+}: UseReportFormOptions): UseReportFormResult => {
   const router = useRouter();
   const [showConfirmModal, setShowConfirmModal] = useState(false);
   const [tagError, setTagError] = useState<string | null>(null);

--- a/front/src/providers/AppStateProvider.tsx
+++ b/front/src/providers/AppStateProvider.tsx
@@ -71,7 +71,7 @@ const AppStateContext = createContext<AppState | undefined>(undefined);
  * @returns アプリ横断の状態と操作
  * @throws {Error} `AppStateProvider` の外で呼ばれた場合
  */
-export const useAppState = () => {
+export const useAppState = (): AppState => {
   const context = useContext(AppStateContext);
   if (!context) {
     throw new Error('useAppState must be used within AppStateProvider');

--- a/front/src/providers/LoadingContext.tsx
+++ b/front/src/providers/LoadingContext.tsx
@@ -37,7 +37,7 @@ export const LoadingProvider = ({
  *
  * @returns ローディング開始関数を持つオブジェクト。プロバイダー外では no-op を返す
  */
-export const useLoading = () => {
+export const useLoading = (): LoadingContextValue => {
   const context = useContext(LoadingContext);
   return context ?? { startLoading: () => {} };
 };


### PR DESCRIPTION
## 概要

`.claude/rules/jsdoc.md`「状態・ロジック層のコメント」の「**戻り値型を先に定義し、コメントは型メンバー側に置く**」に実装を合わせる。インラインのオブジェクトリテラルのままだと各メンバーが「宣言」にならず、JSDoc 規約も Lint も効かないため。

| フック | 対応 |
|---|---|
| `useReport` | `UseReportResult` を定義。`@returns` 1 行に詰め込んでいた 2 値の説明を型メンバーへ移した |
| `usePagination` | `UsePaginationResult` を定義（`paginateSlice` のジェネリクスも型で表現） |
| `useLoginForm` | `UseLoginFormResult` を定義。`isSubmitting` が成功時に解除されない理由をメンバーコメントに明記 |
| `useReportForm` | `UseReportFormResult` を定義（13 メンバー）。`fieldErrors` のキー形式や空 URL 行の扱いを記述 |
| `useAppState` | 実体は `providers/AppStateProvider.tsx`（`hooks/useAppState.ts` は re-export）。既存の `AppState` 型を戻り値型として明示 |
| `useLoading` | 実体は `providers/LoadingContext.tsx`。既存の `LoadingContextValue` を戻り値型として明示 |

`useAppState` / `useLoading` は `hooks/` 側が 1 行の re-export のため、**型注釈は実体のある `providers/` 側に付けた**（re-export に型を重ねると定義が 2 箇所になるため）。

### 補足: `@param` を足さなかった理由

オプション引数が分割代入のフックに `@param options` を足したところ、`jsdoc/check-param-names` が `options.onLogin` 等の**個別記述を要求**してエラーになった。各プロパティの説明は既に `UseXxxOptions` 型のメンバーコメントにあり、`@param` 側へ写すと二重管理になるため、`@param` は付けずに型側へ寄せる方針とした（`jsdoc.md`「型は TS シグネチャが唯一の真実」）。

## テストメモ

- `pnpm typecheck` ✅
- `pnpm lint` ✅（jsdoc ルール込みで警告ゼロ）
- `pnpm test` ✅ 110 tests passed

戻り値の**形は一切変えていない**ため、既存のフックテスト（`useReport` / `usePagination` / `useLoginForm` / `useReportForm` 計 45 件）がそのままグリーンであることが、実挙動が変わっていない裏付けになる。

## ドキュメント更新

影響マップ上、該当なし。規約（`jsdoc.md`）は既に存在し、本 PR はその規約に実装を合わせるもの。

## スクリーンショット

UI 変更なしのため無し。

Closes #144