### PR TITLE
feat(security): CSP ヘッダーを設定する（Report-Only から開始）

### DIFF
--- a/.claude/rules/security.md
+++ b/.claude/rules/security.md
@@ -19,6 +19,7 @@ globs:
 - **レートリミット**を導入する。特に**認証系エンドポイント**（`/api/auth/admin` / `/api/auth/is-allowed`）は、総当たりや列挙を許さないよう厳しく制限する。
   - **現状 Route Handlers に実装は無い**（未対応）。実装は別 issue で扱う。本項は導入時の方針を定めるもので、既存コードの違反を意味しない。
 - **CSP（Content-Security-Policy）ヘッダー**を設定する。Markdown 由来の HTML を描画するため、`rehype-sanitize` によるサニタイズと**多層防御**にする（片方だけに依存しない）。
+  - 実装は `front/next.config.ts` の `headers()`。**現状は `Content-Security-Policy-Report-Only`（観測中）**であり、違反を確認してから強制に切り替える。付随ヘッダー（`X-Frame-Options` / `Referrer-Policy` / `X-Content-Type-Options` / `Permissions-Policy`）は強制済み。ディレクティブの一覧と根拠は `docs/06-security-specification.md` を参照。
 
 ## インジェクション対策
 

--- a/docs/06-security-specification.md
+++ b/docs/06-security-specification.md
@@ -20,6 +20,29 @@
 
 - 全通信は **HTTPS** を必須とする（Vercel デプロイで自動適用）。
 - **CORS** は許可するオリジンを明示的に指定する（`*` は本番で使用しない）。
+- **セキュリティヘッダー**を全レスポンスに付与する（`front/next.config.ts` の `headers()`）。
+
+| ヘッダー | 値 | 状態 |
+|---|---|---|
+| `Content-Security-Policy-Report-Only` | 下表のディレクティブ | **観測中**（強制ではない） |
+| `X-Content-Type-Options` | `nosniff` | 強制 |
+| `X-Frame-Options` | `DENY` | 強制 |
+| `Referrer-Policy` | `strict-origin-when-cross-origin` | 強制 |
+| `Permissions-Policy` | `camera=(), microphone=(), geolocation=()` | 強制 |
+
+### CSP ディレクティブ
+
+| ディレクティブ | 値 | 理由 |
+|---|---|---|
+| `default-src` / `base-uri` / `form-action` | `'self'` | 既定を自オリジンに限定する |
+| `object-src` | `'none'` | プラグイン埋め込みを一切許可しない |
+| `frame-ancestors` | `'none'` | クリックジャッキング対策（`X-Frame-Options` と多層） |
+| `script-src` | `'self' 'unsafe-inline' 'unsafe-eval'` | Next.js のハイドレーション用インラインスクリプトのため。**nonce 化は今後の課題** |
+| `style-src` | `'self' 'unsafe-inline'` | Tailwind / Swagger UI のインラインスタイルのため |
+| `img-src` | `'self' data: blob: https:` | Markdown 本文が外部画像を参照しうるため |
+| `connect-src` | `'self' <NEXT_PUBLIC_SUPABASE_URL>` | Supabase Auth / API との通信を許可する |
+
+**Report-Only から始める理由**: いきなり強制すると Supabase Auth のリダイレクトや `/docs`（Swagger UI）が壊れうる。本番で違反レポートを観測してから `Content-Security-Policy` へ切り替える。Markdown の XSS 対策は `rehype-sanitize` が一次防御であり、CSP はその**多層防御**の位置づけ。
 
 ## インジェクション対策
 

--- a/front/next.config.ts
+++ b/front/next.config.ts
@@ -1,6 +1,58 @@
 import type { NextConfig } from 'next';
 
+// Supabase への接続先。`connect-src` で明示的に許可する必要がある
+// （未設定のビルド（CI のダミー値なし等）でも CSP が壊れないよう空文字を許容する）。
+const supabaseOrigin = process.env.NEXT_PUBLIC_SUPABASE_URL ?? '';
+
+/**
+ * Content-Security-Policy のディレクティブ定義。
+ *
+ * Markdown 由来の HTML は `rehype-sanitize` でサニタイズしているが、単一障害点にしないための
+ * 多層防御として CSP を重ねる（`.claude/rules/security.md`）。
+ *
+ * `script-src` / `style-src` に `'unsafe-inline'` を許しているのは、Next.js の
+ * ハイドレーション用インラインスクリプトと Tailwind / Swagger UI のインラインスタイルのため。
+ * nonce 方式へ移行するには middleware でリクエストごとに nonce を発行する必要があり、
+ * まず Report-Only で違反を観測してから判断する（#147）。
+ */
+const cspDirectives = [
+  "default-src 'self'",
+  "base-uri 'self'",
+  "object-src 'none'",
+  "frame-ancestors 'none'",
+  "form-action 'self'",
+  "script-src 'self' 'unsafe-inline' 'unsafe-eval'",
+  "style-src 'self' 'unsafe-inline'",
+  "font-src 'self' data:",
+  // Markdown 本文が外部画像を参照しうるため https: を広めに許可する。
+  "img-src 'self' data: blob: https:",
+  `connect-src 'self' ${supabaseOrigin}`.trim(),
+].join('; ');
+
 const nextConfig: NextConfig = {
+  /**
+   * 全レスポンスに付与するセキュリティヘッダー。
+   *
+   * CSP は**まず Report-Only で導入**する。いきなり強制すると Supabase Auth のリダイレクトや
+   * Swagger UI（`/docs`）のインラインスタイルで本番が壊れうるため、違反を観測してから
+   * `Content-Security-Policy` へ切り替える。付随ヘッダーは影響が小さいため最初から強制する。
+   *
+   * @returns ヘッダー適用ルールの配列
+   */
+  async headers() {
+    return [
+      {
+        source: '/:path*',
+        headers: [
+          { key: 'Content-Security-Policy-Report-Only', value: cspDirectives },
+          { key: 'X-Content-Type-Options', value: 'nosniff' },
+          { key: 'X-Frame-Options', value: 'DENY' },
+          { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
+          { key: 'Permissions-Policy', value: 'camera=(), microphone=(), geolocation=()' },
+        ],
+      },
+    ];
+  },
   /* config options here */
   reactCompiler: true,
   turbopack: {


### PR DESCRIPTION
## 概要

`.claude/rules/security.md` の CSP 規定に対して実装が無く、XSS 対策が `rehype-sanitize` **のみ**の単一障害点になっていた。`front/next.config.ts` の `headers()` でセキュリティヘッダーを全レスポンスに付与する。

| ヘッダー | 値 | 状態 |
|---|---|---|
| `Content-Security-Policy-Report-Only` | 下記 | **観測中**（強制ではない） |
| `X-Content-Type-Options` | `nosniff` | 強制 |
| `X-Frame-Options` | `DENY` | 強制 |
| `Referrer-Policy` | `strict-origin-when-cross-origin` | 強制 |
| `Permissions-Policy` | `camera=(), microphone=(), geolocation=()` | 強制 |

```
default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none';
form-action 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval';
style-src 'self' 'unsafe-inline'; font-src 'self' data:;
img-src 'self' data: blob: https:; connect-src 'self' <NEXT_PUBLIC_SUPABASE_URL>
```

### 判断

- **Report-Only から開始**（issue の検討事項どおり）。いきなり強制すると Supabase Auth のリダイレクトや `/docs`（Swagger UI）のインラインスタイルで本番が壊れうる。違反を観測してから `Content-Security-Policy` へ切り替える。
- **付随ヘッダーは最初から強制**。影響が小さく、`frame-ancestors 'none'` と `X-Frame-Options: DENY` で多層になる。
- `script-src` に `'unsafe-inline' 'unsafe-eval'` を許しているのは Next.js のハイドレーション用インラインスクリプトのため。**nonce 方式はリクエストごとの発行に middleware が必要**なため、まず観測を優先した（コード内コメントにも理由を記載）。
- `connect-src` は `NEXT_PUBLIC_SUPABASE_URL` から組み立てる。未設定ビルドでも壊れないよう空文字を許容している。

## テストメモ

- `pnpm build` ✅ → `pnpm start` した実サーバーに `curl -I` し、**5 ヘッダーすべてが実際に返ることを確認**（`connect-src` に Supabase オリジンが展開されていることも確認済み）
- `pnpm test:e2e` ✅ **23 passed**（ログイン / 一覧 / 詳細 / 作成 / 編集 / 削除 / Markdown Lab を含む）
- `pnpm typecheck` ✅ / `pnpm lint` ✅ / `pnpm test` ✅ 110 passed

> 補足: 初回の E2E 実行で 20 件が落ちたが、原因は**ヘッダー確認用に起動したままだった `pnpm start` のプロセスに Playwright の `reuseExistingServer` が接続していた**ため（local モードの環境変数が注入されない本番サーバーを見ていた）。ポートを解放して再実行し全件グリーン。CSP とは無関係。

## ドキュメント更新

影響マップ「セキュリティの変更」→ `docs/06-security-specification.md`（ヘッダー一覧・CSP ディレクティブごとの根拠・Report-Only の理由を追記）と `.claude/rules/security.md`（現状が Report-Only であることを明記）を更新済み。

## 残課題

- 本番で違反レポートを観測したうえで `Content-Security-Policy` へ切り替える
- `script-src` の nonce 化（middleware 導入を伴う）

上記は本 PR のスコープ外。切り替え判断ができる段階で別 issue を起票します。

## スクリーンショット

UI 変更なしのため無し（レスポンスヘッダーのみの変更）。

Closes #147