### PR TITLE
chore(ci): vercel.json を Root Directory へ移し、ignoreCommand をルート基準にする

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -5,5 +5,5 @@
       "main": true
     }
   },
-  "ignoreCommand": "git diff --quiet HEAD^ HEAD -- ':(exclude)docs' ':(exclude).claude' ':(exclude).github' ':(exclude)*.md'"
+  "ignoreCommand": "git diff --quiet HEAD^ HEAD -- ':(top,exclude)docs' ':(top,exclude).claude' ':(top,exclude).github' ':(top,exclude)*.md'"
 }


### PR DESCRIPTION
## 概要

#151（PR #157）で入れた Vercel のデプロイ抑止設定が効いていなかった件（#159）の修正。原因は **2 つ重なっていた**。

| # | 原因 | 修正 |
|---|---|---|
| 1 | **`vercel.json` の置き場所が誤り**。Vercel は設定を**プロジェクトの Root Directory から読む**（本リポジトリは `front`）。ルートに置いたファイルは黙って無視されていた | `vercel.json` → **`front/vercel.json`** へ `git mv` |
| 2 | **パススペックが cwd 相対**。`ignoreCommand` は Root Directory を cwd に実行されるため、`':(exclude)docs'` は `front/docs` を指していた | `:(top,exclude)` マジックで**リポジトリルート基準に固定** |

## 原因 1 は推測ではなく実測

この PR の**最初のコミット（`vercel.json` をルートに置いたまま pathspec だけ修正）を push した時点で、Vercel の Preview デプロイが実行された**。

```
Vercel | success | Deployment has completed
```

`git.deploymentEnabled: { "main": true }` が効いていれば、**非 main ブランチでは Preview が出ないはず**だった。出たということは、ルートの `vercel.json` が読まれていないことの直接の証拠になる。ダッシュボードを見ずに Root Directory の設定を特定できた。

## テストメモ

**`front/` を cwd にして**（＝ Vercel と同じ条件で）、実際のマージコミットに対し `ignoreCommand` の判定を検証:

```
478d74a (#158 docs/.claude のみ)  -> exit=0  → ビルドをスキップ ✅
b47dd94 (CSP / front を含む)      -> exit=1  → ビルドを実行     ✅
```

`markdownlint-cli2`（35 files）→ 0 issues。アプリコードの変更は無し。

## ドキュメント更新

- `docs/04-non-functional-specification.md`: 設定ファイルの置き場所（Root Directory）と `:(top,exclude)` の必要性を追記
- `.claude/rules/github-actions.md`: 「**設定ファイルは PaaS が見る場所に置く**。ルートに置いても黙って無視される」を追記

## 完了条件（#159 はまだ閉じない）

**この PR のマージでは #159 をクローズしない。** マージ後にドキュメントのみの PR を 1 本流し、Vercel のチェックが実際にスキップされることを観測してからクローズする（「設定を書いた＝効いた」と見なさないため。今回の再発防止そのもの）。

## スクリーンショット

UI 変更なしのため無し。

Refs #159