### PR TITLE
docs: ルール乖離解消（#142）の作業ログを 11-tasks.md に記録する

### DIFF
--- a/docs/11-tasks.md
+++ b/docs/11-tasks.md
@@ -223,3 +223,22 @@
 - [x] zod + zod-openapi 導入。`front/src/lib/schemas/` を契約の単一ソース化し、`lib/validation.ts` を zod アダプタへ移行（既存 45 テスト互換維持 / 2026-06-13）
 - [x] `pnpm gen:openapi` で `docs/openapi.json`（OpenAPI 3.1）を生成。`docs/07-api-specification.md` の契約記述を生成物参照へ置換（2026-06-13）
 - [x] Swagger UI を `/docs`（管理者のみ）に導入。スペックは管理者ゲート付き `/api/openapi` から取得（2026-06-13）
+
+## ルールと実装の乖離解消（Issue #142）
+
+`.claude/rules/` と実装・CI・ドキュメントを機械的に突き合わせ、検出した乖離をサブ issue に分割して対応した（2026-07-26）。
+
+- [x] 認証ログからメールアドレスを除去（`AppStateProvider.tsx` / Issue #143 / PR #152）
+- [x] カスタムフック 6 本に戻り値型を明示し、コメントを型メンバーへ移動（Issue #144 / PR #154）
+- [x] `api.md` のレスポンス整形をマッパー許可リスト方式に緩和し、`server-only` を導入（Issue #145 / PR #155）
+- [x] CSP を `Report-Only` で導入。付随セキュリティヘッダー 4 種は強制（Issue #147 / PR #156）
+- [x] `constants.tsx` を `constants.ts` にリネーム（Issue #148 / PR #153）
+- [x] `.claude/rules/` の記載漏れ 3 件を補完（IT・typecheck・frontmatter / Issue #149 / PR #150）
+- [x] Vercel のデプロイ発火を制御（Issue #151 / PR #157・#160・#161）
+- [ ] レートリミットの実装（設計のみ完了 / Issue #146 / PR #158）
+- [ ] Vercel のデプロイ抑止が実際に効くことの観測（Issue #159）
+
+### 積み残し
+
+- レートリミット本体の実装（Upstash Redis + 環境変数 2 つの設定が前提 / Issue #146）
+- CSP の `Report-Only` → 強制への切り替え、`script-src` の nonce 化（Issue #147 のフォローアップ）


### PR DESCRIPTION
## 概要

`documentation.md` の影響マップ「タスクの着手・完了・追加 → `docs/11-tasks.md`」に従い、本日実施した #142 系の作業を記録する。あわせて**積み残し**（レートリミット実装 / CSP の強制切り替え）を明示する。

**この PR は #159 の観測を兼ねます。** 変更は `docs/11-tasks.md` の 1 ファイルのみ（ドキュメント専用）なので、`front/vercel.json` の `ignoreCommand` が正しく効いていれば **Vercel のビルドはスキップされる**はずです。結果は #159 に記録します。

| 観測 | 意味 |
|---|---|
| Vercel チェックが出ない / skipped | 設定が効いた → #159 をクローズ |
| これまでどおり Deployment completed | まだ効いていない → #159 で継続調査 |

## テストメモ

`markdownlint-cli2`（35 files）→ **0 issues**。アプリコードの変更が無いため lint / test / build は非該当（`github-actions.md`）。

## ドキュメント更新

本 PR の成果物が `docs/11-tasks.md` の更新そのもの。他の影響マップ該当なし。

## スクリーンショット

UI 変更なしのため無し。

Refs #159, #142