### PR TITLE
[#168-2] テスト DB の接続先を一元化し、本番を指したら実行前に落とす

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -32,13 +32,24 @@ globs:
 - **失敗メッセージに接続先ホストと復旧手順**（テスト DB の起動方法）を含める。原因が分からないと、回避策として接続先を書き換えられてしまう。
 - **ガード自体に UT を書く。** 特に「`DATABASE_URL` に本番 URL が入っていてもガードが汚染されない」ことは、事故の直接原因に対応する回帰テストとして必須。
 
-> **実装状況**: ガードは未導入（Issue #176 で対応）。現行の IT は `tests/integration/global-setup.ts` が Testcontainers の URI で `DATABASE_URL` を常に上書きするため結果的に安全だが、**接続先が非ローカルだったときに失敗する仕組みは無い**。本節はルールが先行しており、新規のテスト・スクリプトは移行を待たず本節に従うこと。
+**実装は `front/tests/support/db-target.ts`**（Issue #176）。接続先を必要とするテスト・スクリプトは、新規・既存を問わず必ずこのモジュールを経由する。
+
+| 関数 | 用途 |
+|---|---|
+| `resolveTestDatabaseUrl(containerUrl?)` | 接続先を解決する。`TEST_DATABASE_URL` → 引数の順に採用し、必ず検証を通す |
+| `assertLocalDatabaseTarget(url, source)` | 既にある URL を検証する。破壊的操作の前に呼ぶ |
+| `hasTestDatabaseUrlOverride()` | 上書きの有無。コンテナ起動が必要かの判断に使う |
+
+> **例外**: `front/prisma.config.ts` は `DATABASE_URL`（本番）を意図的に使う。`prisma db pull` が DB 側で管理されているスキーマを取り込むための正当な経路であり、テスト用の接続先解決には一切関与しない。破壊的サブコマンドの禁止は `production-data.md` を参照。
 
 ## ディレクトリ配置
 
 - ユニットテスト: `front/src/<module>/__tests__/` に配置する
 - 統合テスト: `front/tests/integration/` に配置する
 - E2Eテスト: `front/tests/e2e/` に配置する
+- テスト補助モジュール（接続先ガード等）: `front/tests/support/` に置き、その UT は `front/tests/support/__tests__/` に配置する
+  - **`src/` に置かない**。本番バンドルに混ざるうえ、`dead-code.md` の「未使用 export」として扱われてしまうため
+  - この UT は `pnpm test`（`vitest.config.ts`）で実行される。`tests/e2e` / `tests/integration` のみ別ランナーに分かれる
 
 ## 実行コマンド（`front/` ディレクトリで実行）
 

--- a/docs/08-test-specification.md
+++ b/docs/08-test-specification.md
@@ -93,6 +93,7 @@
 - 実装ファイル: `front/tests/integration/*.test.ts`（reports / reports-id / tags / auth / openapi）。共有ヘルパー: `tests/integration/helpers.ts`。
 - 実行: `pnpm test:integration`（Vitest・node 環境。UT の `pnpm test` とは分離）。CI の playwright ジョブで UT の後に実行。
 - DB: **Testcontainers で実 Postgres を起動**。`globalSetup` で 1 度だけ起動し `tests/integration/schema.sql`（`pnpm gen:test-schema` 生成物）を適用。テスト間 `TRUNCATE`、終了時にコンテナ破棄（**テストデータを残さない**）。前提として **Docker が必要**。
+- **接続先ガード**: 接続先の解決は `front/tests/support/db-target.ts` に集約する。`DATABASE_URL`（本番 Supabase を指す）は**参照しない**。上書きは `TEST_DATABASE_URL` のみで、いずれの経路もホスト allowlist（`localhost` / `127.0.0.1` / `::1`）を通り、**DDL 適用より前に**非ローカルなら throw する。ガード自体の UT は `front/tests/support/__tests__/db-target.test.ts`（21 ケース。`DATABASE_URL` 汚染への耐性を含む）。背景は `.claude/rules/production-data.md` と Issue #168。
 - 方式: route ハンドラを in-process で直接呼び出し（`NextRequest`）、Prisma は実コンテナに接続。認証は `vi.mock('@supabase/supabase-js')` でモック（`requireAdmin` の 401/403/200 分岐は実検証）。
 - カバー: GET 一覧（ページング・content 除外・ヘッダ）/ POST 作成（201・タグ upsert・外部URL・400・401・403）/ GET 詳細（200・404）/ PATCH（部分更新・タグ置換・URL 全削除・404=P2025・400・401/403）/ DELETE（200・CASCADE 実確認・404・401/403）/ tags GET / auth.admin / auth.is-allowed（local・supabase）/ openapi ゲート。33 ケース。
 - RLS/実 Auth は IT のスコープ外（Prisma オーナー接続で RLS はバイパス）。E2E の実 DB 化（Supabase CLI）で別途カバー予定。

--- a/front/prisma.config.ts
+++ b/front/prisma.config.ts
@@ -1,11 +1,26 @@
 import { config } from 'dotenv';
 import { defineConfig } from 'prisma/config';
 
+// このファイルは Prisma CLI の全サブコマンドで読み込まれる。`.env.local` を明示的に読むため、
+// ここで解決される接続先は **本番 Supabase** になる（開発用 Supabase 環境は存在しない）。
+// 正当な用途は `prisma db pull`（DB 側で管理されているスキーマの取り込み）と
+// `prisma generate` / `migrate diff`（DB へ接続しない）に限られる。
+// 破壊的サブコマンド（`db push` / `migrate reset` / `migrate dev` / `migrate deploy`）は
+// `.claude/rules/production-data.md` および `database.md` で禁止されている。
 config({ path: '.env.local' });
 
 export default defineConfig({
   schema: 'prisma/schema.prisma',
   datasource: {
-    url: process.env.DATABASE_URL ?? 'postgresql://placeholder:placeholder@localhost:5432/placeholder',
+    // フォールバックは削除しない。`postinstall` の `prisma generate` は `.env.local` が
+    // 無い環境（CI・クリーンチェックアウト直後）でも走る必要があり、Prisma は url が
+    // 未解決だと起動前に失敗するため。
+    //
+    // なお、これは事故の原因となった `環境変数 ?? ローカル既定` とは向きが逆で安全側に倒れる。
+    // 事故のパターンは「テスト用の接続先を決める際に、値が入っていれば本番を採用してしまう」もの。
+    // ここは「本番を使うのが正（db pull）で、取れないときだけ接続不能な placeholder に落ちる」。
+    // テスト用の接続先解決はこの経路を一切使わない（`tests/support/db-target.ts`）。
+    url:
+      process.env.DATABASE_URL ?? 'postgresql://placeholder:placeholder@localhost:5432/placeholder',
   },
 });

--- a/front/tests/integration/global-setup.ts
+++ b/front/tests/integration/global-setup.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 import { PostgreSqlContainer, type StartedPostgreSqlContainer } from '@testcontainers/postgresql';
 import { Client } from 'pg';
 import type { GlobalSetupContext } from 'vitest/node';
+import { hasTestDatabaseUrlOverride, resolveTestDatabaseUrl } from '../support/db-target';
 
 declare module 'vitest' {
   interface ProvidedContext {
@@ -11,28 +12,38 @@ declare module 'vitest' {
   }
 }
 
-let container: StartedPostgreSqlContainer;
+let container: StartedPostgreSqlContainer | undefined;
 
 /**
- * IT 実行前に一度だけ、実 Postgres コンテナを起動して DDL を適用する。
+ * IT 実行前に一度だけ、実 Postgres に接続して DDL を適用する。
+ *
+ * 接続先は `tests/support/db-target.ts` が解決・検証する（`DATABASE_URL` は参照しない）。
+ * `TEST_DATABASE_URL` による上書きが無い場合のみ Testcontainers を起動する。
  *
  * @param ctx - Vitest globalSetup コンテキスト（ワーカーへ値を渡す `provide` を含む）
  * @returns コンテナを停止する teardown 関数
  */
 export default async function setup({ provide }: GlobalSetupContext) {
-  container = await new PostgreSqlContainer('postgres:16-alpine').start();
-  const uri = container.getConnectionUri();
+  // 上書きがある場合はコンテナを起動しない（自前のローカル Postgres を使うケース）。
+  // その DB は空である必要がある — 下の schema.sql は CREATE TABLE を含むため。
+  if (!hasTestDatabaseUrlOverride()) {
+    container = await new PostgreSqlContainer('postgres:16-alpine').start();
+  }
 
-  // 生成済み DDL（prisma/schema.prisma 由来）をエフェメラルなコンテナに適用する。
+  // 生成済み DDL（prisma/schema.prisma 由来）を適用する。
   // 失敗しても必ずコンテナを停止する（リーク防止）。
+  let uri: string;
   try {
+    // 接続先がローカルであることを、DDL 適用より前に検証する。
+    uri = resolveTestDatabaseUrl(container?.getConnectionUri());
+
     const schema = readFileSync(path.resolve(__dirname, 'schema.sql'), 'utf8');
     const client = new Client({ connectionString: uri });
     await client.connect();
     await client.query(schema);
     await client.end();
   } catch (error) {
-    await container.stop();
+    await container?.stop();
     throw error;
   }
 

--- a/front/tests/integration/setup-env.ts
+++ b/front/tests/integration/setup-env.ts
@@ -1,8 +1,11 @@
 import { inject } from 'vitest';
+import { assertLocalDatabaseTarget } from '../support/db-target';
 
 // 各ワーカーで、テスト本体（および Prisma シングルトン `@/lib/db` の import）より前に
 // DATABASE_URL をテストコンテナの接続先へ確定させる。
-process.env.DATABASE_URL = inject('databaseUrl');
+// globalSetup で検証済みだが、ワーカーは別プロセスで起動するため、Prisma が読む直前の
+// 値をここでも検証する（検証済みの値が渡ってくる前提に寄りかからない）。
+process.env.DATABASE_URL = assertLocalDatabaseTarget(inject('databaseUrl'), 'testcontainers');
 
 // requireAdmin / auth ルートが参照する env。Supabase 呼び出し自体は setup-auth-mock.ts で
 // モックするため、URL/KEY はダミーで良い。ADMIN_EMAIL は認可判定に必須。

--- a/front/tests/support/__tests__/db-target.test.ts
+++ b/front/tests/support/__tests__/db-target.test.ts
@@ -1,0 +1,154 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  assertLocalDatabaseTarget,
+  hasTestDatabaseUrlOverride,
+  resolveTestDatabaseUrl,
+} from '../db-target';
+
+/** Testcontainers が払い出す形の接続 URI（ホストの 127.0.0.1 にポートを公開する）。 */
+const CONTAINER_URL = 'postgresql://test:test@127.0.0.1:54321/test';
+
+/** 本番 Supabase を模した接続先。ガードが必ず拒否しなければならない。 */
+const PRODUCTION_URL = 'postgresql://postgres:secret@db.abcdefgh.supabase.co:5432/postgres';
+
+describe('db-target', () => {
+  // 各テストが process.env を書き換えるため、毎回もとに戻す（テスト間の汚染防止）。
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    delete process.env.TEST_DATABASE_URL;
+    delete process.env.DATABASE_URL;
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  describe('assertLocalDatabaseTarget（正常系）', () => {
+    it.each([
+      ['localhost', 'postgresql://u:p@localhost:5432/db'],
+      ['127.0.0.1', CONTAINER_URL],
+      ['::1', 'postgresql://u:p@[::1]:5432/db'],
+    ])('%s を許可し、渡された URL をそのまま返す', (_host, url) => {
+      expect(assertLocalDatabaseTarget(url, 'testcontainers')).toBe(url);
+    });
+  });
+
+  describe('assertLocalDatabaseTarget（異常系）', () => {
+    it('リモートホストを拒否する', () => {
+      expect(() => assertLocalDatabaseTarget(PRODUCTION_URL, 'TEST_DATABASE_URL')).toThrow(
+        /ローカルではありません/,
+      );
+    });
+
+    it('拒否時のメッセージに接続先ホストを含める（どこへ繋ごうとしたか分からないと原因を追えない）', () => {
+      expect(() => assertLocalDatabaseTarget(PRODUCTION_URL, 'TEST_DATABASE_URL')).toThrow(
+        /host=db\.abcdefgh\.supabase\.co/,
+      );
+    });
+
+    it('拒否時のメッセージに復旧手順を含める（無いと回避策として接続先を書き換えられる）', () => {
+      expect(() => assertLocalDatabaseTarget(PRODUCTION_URL, 'TEST_DATABASE_URL')).toThrow(
+        /pnpm test:integration/,
+      );
+    });
+
+    it('拒否時のメッセージに出どころを含める', () => {
+      expect(() => assertLocalDatabaseTarget(PRODUCTION_URL, 'TEST_DATABASE_URL')).toThrow(
+        /TEST_DATABASE_URL/,
+      );
+    });
+
+    it('ホスト名にローカル名が含まれるだけの偽装ホストを拒否する', () => {
+      expect(() =>
+        assertLocalDatabaseTarget(
+          'postgresql://u:p@localhost.evil.example.com:5432/db',
+          'testcontainers',
+        ),
+      ).toThrow(/ローカルではありません/);
+    });
+
+    it('URL として解釈できない値を拒否する', () => {
+      expect(() => assertLocalDatabaseTarget('not-a-url', 'testcontainers')).toThrow(
+        /URL として解釈できません/,
+      );
+    });
+
+    it('空文字を拒否する', () => {
+      expect(() => assertLocalDatabaseTarget('', 'testcontainers')).toThrow(
+        /URL として解釈できません/,
+      );
+    });
+  });
+
+  describe('resolveTestDatabaseUrl（正常系）', () => {
+    it('上書きが無ければコンテナの URI を使う', () => {
+      expect(resolveTestDatabaseUrl(CONTAINER_URL)).toBe(CONTAINER_URL);
+    });
+
+    it('TEST_DATABASE_URL があればコンテナの URI より優先する', () => {
+      const override = 'postgresql://u:p@localhost:5432/mine';
+      process.env.TEST_DATABASE_URL = override;
+
+      expect(resolveTestDatabaseUrl(CONTAINER_URL)).toBe(override);
+    });
+  });
+
+  describe('resolveTestDatabaseUrl（準正常系）', () => {
+    it('TEST_DATABASE_URL が空文字ならコンテナの URI にフォールバックする', () => {
+      process.env.TEST_DATABASE_URL = '';
+
+      expect(resolveTestDatabaseUrl(CONTAINER_URL)).toBe(CONTAINER_URL);
+    });
+
+    it('TEST_DATABASE_URL が空白のみならコンテナの URI にフォールバックする', () => {
+      process.env.TEST_DATABASE_URL = '   ';
+
+      expect(resolveTestDatabaseUrl(CONTAINER_URL)).toBe(CONTAINER_URL);
+    });
+
+    it('接続先を 1 つも特定できない場合は throw する（黙って既定値へ倒れない）', () => {
+      expect(() => resolveTestDatabaseUrl()).toThrow(/接続先を特定できません/);
+    });
+  });
+
+  describe('resolveTestDatabaseUrl（異常系 / 事故の回帰テスト）', () => {
+    // 姉妹プロジェクトの本番データ全削除は `process.env.DATABASE_URL ?? ローカル既定` が原因だった。
+    // このガードが DATABASE_URL を一切見ないことを、明示的に固定する。
+    it('DATABASE_URL に本番 URL が入っていても、それを接続先に採用しない', () => {
+      process.env.DATABASE_URL = PRODUCTION_URL;
+
+      expect(resolveTestDatabaseUrl(CONTAINER_URL)).toBe(CONTAINER_URL);
+    });
+
+    it('DATABASE_URL に本番 URL が入っていて他に候補が無い場合、フォールバックせず throw する', () => {
+      process.env.DATABASE_URL = PRODUCTION_URL;
+
+      expect(() => resolveTestDatabaseUrl()).toThrow(/接続先を特定できません/);
+    });
+
+    it('TEST_DATABASE_URL がリモートを指していれば throw する（テスト専用変数でも検証は免除しない）', () => {
+      process.env.TEST_DATABASE_URL = PRODUCTION_URL;
+
+      expect(() => resolveTestDatabaseUrl(CONTAINER_URL)).toThrow(/ローカルではありません/);
+    });
+  });
+
+  describe('hasTestDatabaseUrlOverride', () => {
+    it('未設定なら false', () => {
+      expect(hasTestDatabaseUrlOverride()).toBe(false);
+    });
+
+    it('空白のみなら false（コンテナ起動をスキップさせない）', () => {
+      process.env.TEST_DATABASE_URL = '   ';
+
+      expect(hasTestDatabaseUrlOverride()).toBe(false);
+    });
+
+    it('値があれば true', () => {
+      process.env.TEST_DATABASE_URL = CONTAINER_URL;
+
+      expect(hasTestDatabaseUrlOverride()).toBe(true);
+    });
+  });
+});

--- a/front/tests/support/db-target.ts
+++ b/front/tests/support/db-target.ts
@@ -1,0 +1,120 @@
+/**
+ * テスト用 DB の接続先を解決・検証する唯一の窓口。
+ *
+ * IT・E2E・seed 系スクリプトは必ずこのモジュールを経由して接続先を得る。解決ロジックが
+ * 散ると、ガードを通らない経路が後から増えるため（`.claude/rules/testing.md`）。
+ *
+ * **`DATABASE_URL` は決して参照しない。** この変数は本番 Supabase を指し（`front/.env.local`）、
+ * `@prisma/client` の import 時点で `.env` が `process.env` へ読み込まれるためテストコードからも
+ * 見えてしまう。姉妹プロジェクトでは `process.env.DATABASE_URL ?? ローカル既定` というフォール
+ * バックが本番データ全削除を引き起こした（Issue #168 / `.claude/rules/production-data.md`）。
+ * 「未設定なら安全側」に見えて、実際は「値が入っていれば危険側」に倒れる。
+ */
+
+/**
+ * テスト用 DB として接続を許可するホスト。
+ *
+ * ローカルの使い捨て DB のみを想定する。Testcontainers はホストの 127.0.0.1 にポートを
+ * 公開するため、この 3 つで足りる。**リモートホストを足さない** — 追加した時点で、本番を
+ * 含む任意のホストへ到達し得る状態に戻る。
+ */
+const ALLOWED_HOSTS = ['localhost', '127.0.0.1', '::1'] as const;
+
+/** テスト DB を起動する手順。ガード失敗時のメッセージに載せ、回避策として接続先を書き換えられるのを防ぐ。 */
+const RECOVERY_HINT =
+  'テスト DB は `pnpm test:integration` が Testcontainers で起動します（Docker が必要）。' +
+  '自前のローカル Postgres を使う場合のみ TEST_DATABASE_URL に localhost の接続先を設定してください。';
+
+/**
+ * 接続先の解決元。どこから来た値かをエラーメッセージに含めるために使う。
+ */
+type TargetSource =
+  /** テスト専用の環境変数による明示的な上書き */
+  | 'TEST_DATABASE_URL'
+  /** globalSetup が起動した Testcontainers のコンテナ */
+  | 'testcontainers';
+
+/**
+ * URL からホスト名を取り出す。IPv6 リテラルの角括弧は除去する。
+ *
+ * @param url - 検証対象の接続 URL
+ * @returns ホスト名。URL として解釈できない場合は `null`
+ */
+function extractHostname(url: string): string | null {
+  try {
+    // `new URL('postgresql://u:p@[::1]:5432/db').hostname` は '[::1]' を返すため角括弧を剥がす。
+    return new URL(url).hostname.replace(/^\[|\]$/g, '');
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * 接続先がローカルの使い捨て DB を指していることを検証する。破壊的操作の**前**に呼ぶ。
+ *
+ * seed / migrate / `TRUNCATE` / `deleteMany()` を実行してからの検知では手遅れになるため、
+ * スキーマ適用や接続の前段でこの関数を通す。
+ *
+ * @param url - 検証する DB 接続 URL
+ * @param source - この URL の出どころ。エラーメッセージに含める
+ * @returns 検証を通過した `url` をそのまま返す（代入式にそのまま書けるようにするため）
+ * @throws {Error} URL として解釈できない場合、またはホストが許可リストに無い場合
+ */
+export function assertLocalDatabaseTarget(url: string, source: TargetSource): string {
+  const hostname = extractHostname(url);
+
+  if (hostname === null) {
+    throw new Error(
+      `テスト DB の接続先が URL として解釈できません（出どころ: ${source}）。${RECOVERY_HINT}`,
+    );
+  }
+
+  // `includes` は引数を ALLOWED_HOSTS のリテラル union に狭めるためキャストが要る。
+  // `some` + `===` なら string のまま比較でき、アサーションを持ち込まずに済む。
+  if (!ALLOWED_HOSTS.some((allowed) => allowed === hostname)) {
+    throw new Error(
+      `テスト DB の接続先がローカルではありません: host=${hostname}（出どころ: ${source}）。` +
+        `許可されるのは ${ALLOWED_HOSTS.join(' / ')} のみです。` +
+        `本番 DB を破壊しないため中断しました。${RECOVERY_HINT}`,
+    );
+  }
+
+  return url;
+}
+
+/**
+ * テスト用 DB の接続先を解決する。
+ *
+ * 優先順位は `TEST_DATABASE_URL` → 引数の `containerUrl`。**`DATABASE_URL` は参照しない**。
+ * どちらの経路でも {@link assertLocalDatabaseTarget} を通すため、本番を指した接続先が
+ * 返ることはない。
+ *
+ * @param containerUrl - Testcontainers が払い出した接続 URI。環境変数による上書きが無い場合に使う
+ * @returns 検証済みの接続 URL
+ * @throws {Error} 接続先を 1 つも特定できない場合、または特定した接続先がローカルでない場合
+ */
+export function resolveTestDatabaseUrl(containerUrl?: string): string {
+  const override = process.env.TEST_DATABASE_URL?.trim();
+
+  if (override) {
+    return assertLocalDatabaseTarget(override, 'TEST_DATABASE_URL');
+  }
+
+  if (containerUrl) {
+    return assertLocalDatabaseTarget(containerUrl, 'testcontainers');
+  }
+
+  throw new Error(`テスト DB の接続先を特定できません。${RECOVERY_HINT}`);
+}
+
+/**
+ * 環境変数による接続先の上書きが指定されているか。
+ *
+ * globalSetup が「コンテナを起動する必要があるか」を判断するために使う。値の検証は行わない
+ * （検証は {@link resolveTestDatabaseUrl} の責務）。
+ *
+ * @returns `TEST_DATABASE_URL` に空でない値が設定されていれば `true`
+ */
+export function hasTestDatabaseUrlOverride(): boolean {
+  return Boolean(process.env.TEST_DATABASE_URL?.trim());
+}

--- a/front/vitest.config.ts
+++ b/front/vitest.config.ts
@@ -5,9 +5,13 @@ export default defineConfig({
   test: {
     environment: 'happy-dom',
     setupFiles: ['./src/test/setup.ts'],
-    // UT はソース隣接の __tests__ のみ。tests/ 配下（e2e / integration）は別ランナーで実行する。
-    include: ['src/**/*.{test,spec}.{ts,tsx}'],
-    exclude: ['node_modules', 'tests/**'],
+    // UT はソース隣接の __tests__ と、テスト補助モジュール（tests/support/）の __tests__。
+    // tests/e2e・tests/integration は別ランナーで実行するため除外する。
+    // tests/support/ を含めるのは、接続先ガード（db-target.ts）が本番 DB 破壊を防ぐ
+    // 実装であり、それ自体に UT が必須のため（.claude/rules/testing.md）。本番バンドルに
+    // 混ぜないよう src/ ではなく tests/ 側に置いている。
+    include: ['src/**/*.{test,spec}.{ts,tsx}', 'tests/support/**/*.{test,spec}.ts'],
+    exclude: ['node_modules', 'tests/e2e/**', 'tests/integration/**'],
     pool: 'vmThreads',
     // Node v24 OOM occurs during worker cleanup (after all tests complete).
     // This flag suppresses that infrastructure error so the exit code stays 0.


### PR DESCRIPTION
## 変更種別

仕様追加

## 概要

テスト用 DB の接続先解決を `front/tests/support/db-target.ts` に集約し、ホスト allowlist で検証して**破壊的操作の前に throw** させた。#168（本番 DB 破壊の再発防止）のサブ issue 2/2 で、**実装本体**にあたる。

## 関連 issue

Closes #176（親: #168）

## 背景・目的

姉妹プロジェクト `youtube-my-collection` で、テスト DB の接続先が本番 Supabase を指し、seed の `deleteMany()` により**本番データが全削除された**（kojikawazu/youtube-my-collection#175）。原因は `process.env.DATABASE_URL ?? ローカル既定`。`@prisma/client` の import 時点で `.env` が `process.env` に載るため、この書き方は `.env` の本番 URL を拾う。**「未設定なら安全側」に見えて、実際は「値が入っていれば危険側」に倒れる。**

#177（#168-1）でルールは定めたが、**実装が入るまで既存経路は守られていない**状態だった。本 PR がそれを埋める。

## 追加仕様

### `front/tests/support/db-target.ts`（新規）

| 関数 | 役割 |
|---|---|
| `resolveTestDatabaseUrl(containerUrl?)` | `TEST_DATABASE_URL` → 引数の順で接続先を決め、必ず検証を通す |
| `assertLocalDatabaseTarget(url, source)` | 既にある URL を検証する。破壊的操作の前に呼ぶ |
| `hasTestDatabaseUrlOverride()` | 上書きの有無。コンテナ起動要否の判断に使う |

- **`DATABASE_URL` を一切参照しない。** 接続先の決定にこの変数を使わないことがガードの本体。
- allowlist は `localhost` / `127.0.0.1` / `::1` の 3 つ。リモートを足せば本番へ到達し得る状態に戻るため、その旨をコメントで固定した。
- 失敗メッセージに**接続先ホスト・出どころ・復旧手順**を含める。原因が分からないと、回避策として接続先を書き換えられてしまう（`production-data.md` が禁じている行動）。

### 呼び出し側の変更

- `tests/integration/global-setup.ts` — 接続先を resolver 経由で取得し、**`schema.sql` の適用より前に**検証する。`TEST_DATABASE_URL` の上書きがある場合はコンテナを起動しない。検証失敗時もコンテナを確実に停止する
- `tests/integration/setup-env.ts` — **ワーカー側でも再検証する**。ワーカーは別プロセスで起動するため、「親で検証済み」という前提に寄りかからない
- `vitest.config.ts` — `tests/support/**` の UT を `pnpm test` の対象に加えた

## 既存への影響

**テストインフラのみ。アプリケーションコード（`src/`）の差分はゼロ。**

- 既存の IT 33 件は挙動が変わらない（接続先は従来どおり Testcontainers）
- 既存の UT 110 件に影響なし
- `TEST_DATABASE_URL` を設定しなければ、開発者の手元でも従来と同じ動作

### `prisma.config.ts` — コメントのみ、挙動は不変

#176 のチェックリストにある「`?? placeholder` フォールバックの見直し」を行い、**残すのが正しい**と判断してその理由をコメントに残した。

このフォールバックは**事故のパターンと向きが逆**である。事故は「テスト用の接続先を決める際に、値が入っていれば本番を採用してしまう」もので、危険側に倒れる。ここは「本番を使うのが正（`db pull`）で、取れないときだけ接続不能な placeholder に落ちる」ため安全側に倒れる。`postinstall` の `prisma generate` が `.env.local` の無い環境でも走る必要があり、削除するとクリーンチェックアウトが壊れる。

## 受け入れ基準

- [x] テスト経路のどこからも `DATABASE_URL` が**接続先の決定**に使われていない
- [x] リモートホストを指した状態でテストを起動すると、破壊的操作の前に throw する（実測。下記）
- [x] `DATABASE_URL` に本番 URL が入っていても接続先が汚染されない（実測。下記）
- [x] ガードの UT が正常/準正常/異常をすべて含む（`testing.md`）
- [x] `pnpm test` / `pnpm test:integration` / `pnpm lint` / `pnpm typecheck` がすべて green
- [x] `as` / `!` を使っていない（`typescript.md`。`includes` のキャストを `some` + `===` に置き換えた）

## テスト

### 追加した UT — 21 ケース（`tests/support/__tests__/db-target.test.ts`）

| 分類 | 内容 |
|---|---|
| 正常 | `localhost` / `127.0.0.1` / `::1`（IPv6 の角括弧を含む形）を許可し、URL をそのまま返す |
| 正常 | 上書きが無ければコンテナ URI を使う / `TEST_DATABASE_URL` が優先される |
| 準正常 | `TEST_DATABASE_URL` が空文字・空白のみならコンテナ URI にフォールバック |
| 準正常 | 接続先を 1 つも特定できなければ throw（**黙って既定値へ倒れない**） |
| 異常 | リモートホストを拒否。メッセージにホスト・出どころ・復旧手順を含む |
| 異常 | `localhost.evil.example.com` のような**偽装ホスト**を拒否 |
| 異常 | URL として解釈できない値・空文字を拒否 |
| **異常（回帰）** | **`DATABASE_URL` に本番 URL が入っていても接続先に採用しない** |
| **異常（回帰）** | `DATABASE_URL` が本番で他に候補が無い場合、フォールバックせず throw |
| 異常 | `TEST_DATABASE_URL` がリモートを指していれば throw（テスト専用変数でも検証を免除しない） |

### 実行結果

```text
pnpm test             →  131 passed (9 files)   ※ 既存 110 + 新規 21
pnpm test:integration →   33 passed (5 files)
pnpm typecheck        →  green
pnpm lint             →  green
markdownlint          →  0 issues / 44 files
```

### ガードが実際に発火することの実測

**ユニットテストだけでは「配線されていること」を確認できない**ため、実際のスイートに対して確かめた。

リモートを指した場合 — DB へ接続する前に中断する:

```console
$ TEST_DATABASE_URL='postgresql://...@db.fake-project.supabase.co:5432/postgres' pnpm test:integration
Error: テスト DB の接続先がローカルではありません: host=db.fake-project.supabase.co（出どころ: TEST_DATABASE_URL）。
許可されるのは localhost / 127.0.0.1 / ::1 のみです。本番 DB を破壊しないため中断しました。
テスト DB は `pnpm test:integration` が Testcontainers で起動します（Docker が必要）。…
ELIFECYCLE Command failed with exit code 1
```

`DATABASE_URL` が本番で汚染されている場合 — 影響を受けずコンテナで通る（事故の直接原因の再現テスト）:

```console
$ DATABASE_URL='postgresql://...@db.fake-project.supabase.co:5432/postgres' pnpm test:integration
Test Files  5 passed (5)
     Tests  33 passed (33)
```

### E2E の確認

`tests/e2e/` を検査し、**DB に一切触れない**ことを確認した（`fetch` / `prisma` / `api/` の参照ゼロ）。`playwright.config.ts` が `NEXT_PUBLIC_AUTH_MODE=local` / `NEXT_PUBLIC_DATA_MODE=local` を注入し、localStorage モードで動作する。したがって E2E はガードの対象外でよい。

## ドキュメント

- `.claude/rules/testing.md` — #177 で入れた「実装状況: 未導入」の注記を、実装後の内容（3 関数の役割・`prisma.config.ts` が例外である理由）に差し替え。あわせて「ディレクトリ配置」に `tests/support/` を追加した
- `docs/08-test-specification.md` — IT 節に接続先ガードの記述を追加（#177 の PR で「実装が入る時点で追加するのが適切」と判断した分）

### `tests/support/` を `src/` に置かなかった理由

`testing.md` は UT を `src/<module>/__tests__/` に置くと定めているが、このモジュールは `src/` に置けない。**本番バンドルに混ざる**うえ、アプリから参照されないため `dead-code.md` の「未使用 export」として扱われてしまう。`tests/support/` に置き、`vitest.config.ts` の `include` を拡張して `pnpm test` の対象にした。判断理由は `testing.md` のディレクトリ配置節にも記載した。

## 残課題

### #178 — `prisma.config.ts` の破壊的サブコマンド拒否（**本 PR のスコープ外・要対応**）

本 PR の作業中に、**テスト経路とは別の未防御な経路**を見つけたため起票した。

`prisma.config.ts` は `config({ path: '.env.local' })` で本番の `DATABASE_URL` を読み込み、**Prisma CLI の全サブコマンドで読まれる**。つまり `pnpm prisma db push` や `pnpm prisma migrate reset` は**現状そのまま本番に届く**。止めているのはルールだけで、機械的なガードは無い。

本 PR のガードはテスト経路のみを対象とするため、この経路は通らない。#176 のスコープ（テスト DB の接続先）と別の攻撃面であり、1 issue = 1 PR の原則に従って分離した。本 PR では `prisma.config.ts` に**危険性を説明するコメントのみ**を追加している。

### その他

- **#171** — `codex.md` の取り込み（独立）
- `playwright.config.ts` の `webServer.command` が `npm run dev` になっている（`coding-standards.md` は pnpm 指定）。本 PR の論点と無関係なため触っていない

🤖 Generated with [Claude Code](https://claude.com/claude-code)