### PR TITLE
fix(tsconfig): tests/ を型チェック対象に含める

### DIFF
--- a/docs/11-tasks.md
+++ b/docs/11-tasks.md
@@ -105,6 +105,7 @@
 - [x] 統合テスト（IT）基盤を導入: Testcontainers(Postgres) + Auth モックで APIルート×実 DB を検証（`front/tests/integration/`・`pnpm test:integration`・`gen:test-schema` で DDL 生成・33ケース / 2026-07-04）
 - [x] CI（playwright ジョブ）に IT 実行を追加（UT の後 / 2026-07-04）
 - [ ] E2E/シナリオの実 DB 化（Supabase CLI ローカルスタック・実 Auth/RLS・テストデータ後始末必須 / PR2 予定）
+- [x] `tsconfig.json` の `exclude` から `tests` を外し、`front/tests/` 配下を `pnpm typecheck` の対象に含めた（型エラー 0 件・Vitest / Playwright とも `globals` 未使用のため型衝突なし / Issue #183 / 2026-08-09）
 
 ## デプロイ/運用
 

--- a/front/tsconfig.json
+++ b/front/tsconfig.json
@@ -30,5 +30,5 @@
     ".next/dev/types/**/*.ts",
     "**/*.mts"
   ],
-  "exclude": ["node_modules", "tests"]
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## 変更種別

バグ修正

## 概要

`front/tsconfig.json` の `exclude` から `tests` を外し、`front/tests/` 配下を `pnpm typecheck`（`tsc --noEmit`）の検査対象に含めた。変更は実質 1 行。

## 関連 issue

Fixes #183

## 事象

- 再現手順: `front/tests/` 配下のファイルに型エラーを書き、`pnpm typecheck` / `pnpm test` / `pnpm build` / CI を実行する
- 期待する挙動: `pnpm typecheck` が型エラーを検出して失敗する
- 実際の挙動: どれも成功する。型エラーはどこでも検出されない
- 影響範囲（対象ユーザー・データ・期間）: エンドユーザーへの影響なし（開発時の型安全性のみ）。対象は `front/tests/` 配下 13 ファイルで、`exclude` に `tests` が入った時点から現在まで

## 原因

`front/tsconfig.json` の `exclude` に `tests` が指定されており、`include` の `**/*.ts` にマッチする `front/tests/` 配下が tsc のプログラムから除外されていた。

Vitest（esbuild）も Playwright も**トランスパイルするだけで型を検査しない**ため、テストコードだけが型検査の担保から外れていた。とくに #179 で追加した `tests/support/db-target.ts` は**本番 DB の破壊を防ぐガード**であり、対象の重要度に対して防御が弱い状態だった。

`.claude/rules/typescript.md` は「型チェックは `tsc --noEmit` を CI で実行する。ビルドが通ることは型が正しいことを意味しない」と定めており、この状態はルールを満たしていなかった。

## 修正方針

`exclude` から `tests` を外した。`include` には既に `**/*.ts` があるため、これだけで `tests/` 配下 13 ファイル全てがプログラムに入る（`tsc --listFiles` で確認済み）。

issue が想定していた難所は**いずれも発生しなかった**ため、対応を追加していない。

| 想定された難所 | 実際 |
|---|---|
| Playwright と Vitest の `expect` 等がグローバルで衝突する | 発生せず。両者とも `globals: true` を使っておらず、各テストが `import { describe, expect } from 'vitest'` と明示 import しているため、グローバル名前空間に生えない |
| `tsconfig.tests.json` への分割が必要 | 不要。型エラー 0 件のため単一 tsconfig のまま |
| `tests/integration/global-setup.ts` の `declare module 'vitest'`（`ProvidedContext` 拡張）の解決が変わる | 同一プログラム内に入るため正しく解決される |

これに伴い、#182 で共有ヘルパーを「型チェック対象だから」という理由で `scripts/` に置かざるを得なかった制約も解消され、今後は `.claude/rules/testing.md` の配置規約だけで置き場所を決められる。

## 再発防止

なし（機械的なガードは追加していない）。

`exclude` に `tests` を戻しても、型エラーが 0 件である限り CI は緑を保つため検出できない。ただし現時点でその防御を足すのは過剰と判断した（issue の完了条件にも含まれていない）。tsconfig の `exclude` はレビュー対象の差分に必ず現れるため、レビューで検出する前提とする。

## 受け入れ基準

- [x] `front/tests/` 配下 13 ファイルが tsc のプログラムに含まれる（`tsc --noEmit --listFiles` に全ファイルが現れる）
- [x] `pnpm typecheck` が green（型エラー 0 件）
- [x] CI の `static-analysis` ジョブで検査される（`test.yml` は `front/**` で発火し `pnpm typecheck` を実行するため、ワークフロー側の変更は不要）
- [x] `pnpm build` が成功する（`next build` は独自に tsconfig を読んで型検査するため、テストファイルの取り込みがビルドを壊さないこと）

## テスト

テストの追加・修正はなし（設定変更のみで、ランタイムの挙動に一切触れない）。既存の検証をローカルで全て実行した。

- [x] `pnpm typecheck` — pass（エラー 0）
- [x] `pnpm lint` — pass
- [x] `pnpm test` — 168 tests / 10 files pass
- [x] `pnpm build` — pass（全 13 ルート生成）
- [ ] `pnpm test:integration` — **未実行**。Docker 起動を伴う一方、本変更はコンパイル時の検査範囲のみでランタイム挙動に影響しないため CI に委ねた

## ドキュメント

- `docs/11-tasks.md` — テストセクションに完了項目を追記（`.claude/rules/documentation.md` の影響マップ「タスクの着手・完了」）

その他のドキュメントは更新不要と判断した。API・データモデル・セキュリティ・CI 構成のいずれも変更しておらず、`front/README.md` の `tsconfig.json` への言及もファイル一覧の一項目のみで内容に踏み込んでいないため。

## スクリーンショット

なし（UI 変更なし）