### PR TITLE
chore(ci): Prettier の差分ゼロを CI で検証する

### DIFF
--- a/.claude/rules/commands.md
+++ b/.claude/rules/commands.md
@@ -10,12 +10,12 @@ globs:
 ## 開発・ビルド
 
 ```bash
-pnpm install   # 依存インストール（postinstall で prisma generate が自動実行される）
-pnpm dev       # 開発サーバー起動（http://localhost:3000）
-pnpm build     # プロダクションビルド
-pnpm start     # プロダクションビルド配信
-pnpm lint      # ESLint 実行（CI のグリーン条件 / git-workflow.md 参照）
-pnpm typecheck # tsc --noEmit（CI 必須。ビルドは型を検査しないため別途実行する / typescript.md 参照）
+pnpm install      # 依存インストール（postinstall で prisma generate が自動実行される）
+pnpm dev          # 開発サーバー起動（http://localhost:3000）
+pnpm build        # プロダクションビルド
+pnpm start        # プロダクションビルド配信
+pnpm lint         # ESLint 実行（CI のグリーン条件 / git-workflow.md 参照）
+pnpm typecheck    # tsc --noEmit（CI 必須。ビルドは型を検査しないため別途実行する / typescript.md 参照）
 pnpm format       # Prettier 整形（書き込み）
 pnpm format:check # Prettier 差分ゼロの検証（CI 必須 / static-analysis.md 参照）
 ```

--- a/.claude/rules/commands.md
+++ b/.claude/rules/commands.md
@@ -16,8 +16,12 @@ pnpm build     # プロダクションビルド
 pnpm start     # プロダクションビルド配信
 pnpm lint      # ESLint 実行（CI のグリーン条件 / git-workflow.md 参照）
 pnpm typecheck # tsc --noEmit（CI 必須。ビルドは型を検査しないため別途実行する / typescript.md 参照）
-pnpm format    # Prettier 整形
+pnpm format       # Prettier 整形（書き込み）
+pnpm format:check # Prettier 差分ゼロの検証（CI 必須 / static-analysis.md 参照）
 ```
+
+- 整形の設定は `front/.prettierrc` が唯一の正本とする（`.prettierrc.json` 等を併置しない。Prettier は最初に見つけた 1 つだけを読むため、二重に置くと片方が黙って無視される）。
+- 生成物・ロックファイルは `front/.prettierignore` で対象外にする（整形すると生成のたびに差分が出るため）。
 
 ## コード生成
 

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,10 @@
+# git blame から除外するコミット（整形のみで挙動を変えていないもの）。
+#
+# ローカルで有効にする:
+#   git config blame.ignoreRevsFile .git-blame-ignore-revs
+# GitHub の blame ビューはこのファイルを自動で参照する。
+#
+# 追加してよいのは「整形・リネームのみで、ロジックを 1 行も変えていない」コミットに限る。
+
+# style: Apply Prettier to the whole front workspace (#186)
+ef4edebb7153dbee83e5680758202302ee98bf40

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,6 +55,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Format check (Prettier)
+        run: pnpm format:check
+
       - name: Lint (ESLint)
         run: pnpm lint
 

--- a/docs/04-non-functional-specification.md
+++ b/docs/04-non-functional-specification.md
@@ -13,7 +13,7 @@
 
 - デプロイ: 本番運用はVercelで実施（デプロイ必須）。
 - CI/CD: 自動デプロイのみ（Vercel連携を前提）。`main` ブランチのみ本番デプロイ。プレビューは不要。
-- CI: GitHub Actions（`.github/workflows/test.yml`）で自動実行する。`static-analysis` ジョブが静的解析（ESLint `pnpm lint` + 型チェック `pnpm typecheck`）、`playwright` ジョブがユニット（Vitest）→ 統合（IT・Testcontainers Postgres・`pnpm test:integration`）→ E2E（Playwright）を順に担当し、両ジョブを並列実行する。IT は ubuntu-latest 同梱の Docker で実 Postgres を起動する。
+- CI: GitHub Actions（`.github/workflows/test.yml`）で自動実行する。`static-analysis` ジョブが静的解析（整形検証 `pnpm format:check` + ESLint `pnpm lint` + 型チェック `pnpm typecheck`）、`playwright` ジョブがユニット（Vitest）→ 統合（IT・Testcontainers Postgres・`pnpm test:integration`）→ E2E（Playwright）を順に担当し、両ジョブを並列実行する。IT は ubuntu-latest 同梱の Docker で実 Postgres を起動する。
 - テスト: 正常/準正常/異常をすべて必須とする（ユニット + E2E）。詳細は `docs/08-test-specification.md`。
 - 監視/ログ: 不具合を早期発見できるログ設計を意識する。
 - セキュリティ: Markdown表示はサニタイズ必須。Supabase RLSは「公開閲覧 + 認証ユーザーのみ書き込み」を採用する（詳細: `docs/06-security-specification.md`）。

--- a/docs/11-tasks.md
+++ b/docs/11-tasks.md
@@ -114,6 +114,7 @@
 - [x] Vercel自動デプロイを設定（mainのみ、プレビューなし）
 - [x] 本番環境変数を整備（必要が出た場合のみ）
 - [x] 本番動作確認（Google OAuth/初期表示）
+- [x] Prettier の差分ゼロを CI で検証（`format:check` 追加・`static-analysis` ジョブへ組込み・未整形 39 ファイルを一括整形・`.prettierrc.json` の重複設定を削除・`.git-blame-ignore-revs` 追加 / Issue #186 / 2026-08-09）
 
 ## パフォーマンス改善
 

--- a/front/.prettierignore
+++ b/front/.prettierignore
@@ -12,7 +12,5 @@ test-results
 # シークレット
 .env*
 
-# 生成物（整形すると生成のたびに差分が出る）
+# 生成物（pnpm が管理するため、整形しても install のたびに戻る）
 pnpm-lock.yaml
-prisma/generated
-tests/integration/schema.sql

--- a/front/.prettierignore
+++ b/front/.prettierignore
@@ -1,8 +1,18 @@
+# 依存・ビルド成果物
 node_modules
 .next
 dist
 build
+
+# テスト・レポートの出力
 coverage
 playwright-report
 test-results
+
+# シークレット
 .env*
+
+# 生成物（整形すると生成のたびに差分が出る）
+pnpm-lock.yaml
+prisma/generated
+tests/integration/schema.sql

--- a/front/.prettierrc.json
+++ b/front/.prettierrc.json
@@ -1,7 +1,0 @@
-{
-  "printWidth": 100,
-  "tabWidth": 2,
-  "semi": true,
-  "singleQuote": true,
-  "trailingComma": "all"
-}

--- a/front/README.md
+++ b/front/README.md
@@ -22,19 +22,19 @@ Markdown レポートの保存・閲覧 UI の**実装ディレクトリ**です
 
 ## 技術スタック
 
-| 領域 | 採用技術 |
-|---|---|
-| 言語 | TypeScript 5（strict） |
-| フレームワーク | Next.js 16（App Router） / React 19 |
-| スタイリング | TailwindCSS v4 |
-| Markdown | react-markdown 10 + remark-gfm 4 + rehype-sanitize 6 |
-| 認証 | Supabase Auth（Google OAuth） |
-| DB / ORM | Supabase Postgres（RLS） / Prisma 6（`db pull` のみ・マイグレーション禁止） |
-| BFF | Next.js Route Handlers（`src/app/api/*`） |
-| バリデーション / API契約 | zod 4 + zod-openapi 5（スキーマから OpenAPI 生成） |
-| テスト | Vitest（ユニット / 統合） + Testcontainers（IT用 Postgres） + Playwright（E2E） |
-| 静的解析 | ESLint 9 + Prettier 3 |
-| パッケージマネージャ | **pnpm**（npm / yarn は使用しない） |
+| 領域                     | 採用技術                                                                        |
+| ------------------------ | ------------------------------------------------------------------------------- |
+| 言語                     | TypeScript 5（strict）                                                          |
+| フレームワーク           | Next.js 16（App Router） / React 19                                             |
+| スタイリング             | TailwindCSS v4                                                                  |
+| Markdown                 | react-markdown 10 + remark-gfm 4 + rehype-sanitize 6                            |
+| 認証                     | Supabase Auth（Google OAuth）                                                   |
+| DB / ORM                 | Supabase Postgres（RLS） / Prisma 6（`db pull` のみ・マイグレーション禁止）     |
+| BFF                      | Next.js Route Handlers（`src/app/api/*`）                                       |
+| バリデーション / API契約 | zod 4 + zod-openapi 5（スキーマから OpenAPI 生成）                              |
+| テスト                   | Vitest（ユニット / 統合） + Testcontainers（IT用 Postgres） + Playwright（E2E） |
+| 静的解析                 | ESLint 9 + Prettier 3                                                           |
+| パッケージマネージャ     | **pnpm**（npm / yarn は使用しない）                                             |
 
 詳細な技術選定理由は [../docs/09-architecture-specification.md](../docs/09-architecture-specification.md) を参照。
 
@@ -122,11 +122,11 @@ pnpm start    # ビルド成果物を配信
 
 このアプリは認証・データ取得をそれぞれ2モードで切り替えます。環境変数 `NEXT_PUBLIC_AUTH_MODE` / `NEXT_PUBLIC_DATA_MODE` で制御し、**未設定なら supabase モード**になります。
 
-| | local モード（`=local`） | supabase モード（既定） |
-|---|---|---|
-| 認証（`NEXT_PUBLIC_AUTH_MODE`） | ダミー認証。`ADMIN_EMAIL` 不要 | Supabase Auth（Google OAuth）+ `ADMIN_EMAIL` 照合 |
-| データ（`NEXT_PUBLIC_DATA_MODE`） | localStorage のダミーデータ | Supabase Postgres（Prisma 経由） |
-| 用途 | E2E / UI 確認（`.env.local` 不要） | 開発・本番 |
+|                                   | local モード（`=local`）           | supabase モード（既定）                           |
+| --------------------------------- | ---------------------------------- | ------------------------------------------------- |
+| 認証（`NEXT_PUBLIC_AUTH_MODE`）   | ダミー認証。`ADMIN_EMAIL` 不要     | Supabase Auth（Google OAuth）+ `ADMIN_EMAIL` 照合 |
+| データ（`NEXT_PUBLIC_DATA_MODE`） | localStorage のダミーデータ        | Supabase Postgres（Prisma 経由）                  |
+| 用途                              | E2E / UI 確認（`.env.local` 不要） | 開発・本番                                        |
 
 - 本番は **supabase モードのみ**。local モードは E2E 専用で、本番データは表示しません。
 - E2E 実行時は `playwright.config.ts` が両変数に `local` を注入します（手動設定は不要）。

--- a/front/eslint.config.mjs
+++ b/front/eslint.config.mjs
@@ -1,7 +1,7 @@
-import { defineConfig, globalIgnores } from "eslint/config";
-import nextVitals from "eslint-config-next/core-web-vitals";
-import nextTs from "eslint-config-next/typescript";
-import jsdoc from "eslint-plugin-jsdoc";
+import { defineConfig, globalIgnores } from 'eslint/config';
+import nextVitals from 'eslint-config-next/core-web-vitals';
+import nextTs from 'eslint-config-next/typescript';
+import jsdoc from 'eslint-plugin-jsdoc';
 
 const eslintConfig = defineConfig([
   ...nextVitals,
@@ -10,43 +10,43 @@ const eslintConfig = defineConfig([
   // 有効ルールの唯一の真実はこのブロック。方針の根拠は .claude/rules/jsdoc.md。
   // require-jsdoc は採用しない（JSDoc の付与は強制せず、書いたら完全であることを強制する）。
   {
-    files: ["src/**/*.{ts,tsx}"],
+    files: ['src/**/*.{ts,tsx}'],
     plugins: { jsdoc },
     // TS 前提。型は JSDoc ではなくシグネチャに委ねる。
-    settings: { jsdoc: { mode: "typescript" } },
+    settings: { jsdoc: { mode: 'typescript' } },
     rules: {
       // 型の再掲を禁止（TS シグネチャが型の唯一の真実）。
-      "jsdoc/no-types": "error",
+      'jsdoc/no-types': 'error',
       // JSDoc ブロックを持つ関数は全引数を @param で説明する。
       // 分割代入 props は型（XxxProps）が真実なので props.x 単位には展開しない。
-      "jsdoc/require-param": ["error", { checkDestructured: false, checkDestructuredRoots: false }],
-      "jsdoc/require-param-description": "error",
+      'jsdoc/require-param': ['error', { checkDestructured: false, checkDestructuredRoots: false }],
+      'jsdoc/require-param-description': 'error',
       // @param 名と実引数名を突き合わせる（名前ズレ・順序・過不足を検出）。
-      "jsdoc/check-param-names": "error",
+      'jsdoc/check-param-names': 'error',
       // 返り値がある関数は @returns に意味を書く（.tsx コンポーネントは後続ブロックで除外）。
-      "jsdoc/require-returns": "error",
-      "jsdoc/require-returns-description": "error",
+      'jsdoc/require-returns': 'error',
+      'jsdoc/require-returns-description': 'error',
       // 書いた JSDoc の体裁を整える。
-      "jsdoc/check-alignment": "warn",
-      "jsdoc/no-multi-asterisks": "warn",
+      'jsdoc/check-alignment': 'warn',
+      'jsdoc/no-multi-asterisks': 'warn',
     },
   },
   {
     // React コンポーネント（JSX を返す .tsx）は @returns を要求しない（「@returns …の要素」はノイズ）。
     // .ts のフック / lib / API では @returns 必須のまま。
-    files: ["src/**/*.tsx"],
+    files: ['src/**/*.tsx'],
     rules: {
-      "jsdoc/require-returns": "off",
-      "jsdoc/require-returns-description": "off",
+      'jsdoc/require-returns': 'off',
+      'jsdoc/require-returns-description': 'off',
     },
   },
   // Override default ignores of eslint-config-next.
   globalIgnores([
     // Default ignores of eslint-config-next:
-    ".next/**",
-    "out/**",
-    "build/**",
-    "next-env.d.ts",
+    '.next/**',
+    'out/**',
+    'build/**',
+    'next-env.d.ts',
   ]),
 ]);
 

--- a/front/package.json
+++ b/front/package.json
@@ -17,7 +17,8 @@
     "test:e2e:report": "playwright show-report",
     "gen:openapi": "tsx scripts/gen-openapi.ts",
     "gen:test-schema": "tsx scripts/gen-test-schema.ts",
-    "format": "prettier --write ."
+    "format": "prettier --write .",
+    "format:check": "prettier --check ."
   },
   "dependencies": {
     "@prisma/client": "^6.19.2",

--- a/front/postcss.config.mjs
+++ b/front/postcss.config.mjs
@@ -1,6 +1,6 @@
 const config = {
   plugins: {
-    "@tailwindcss/postcss": {},
+    '@tailwindcss/postcss': {},
   },
 };
 

--- a/front/src/app/api/reports/[id]/route.ts
+++ b/front/src/app/api/reports/[id]/route.ts
@@ -186,12 +186,10 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
 
     const euList =
       result.externalUrls ??
-      (
-        await prisma.externalUrl.findMany({
-          where: { reportId: id },
-          select: { id: true, url: true, label: true },
-        })
-      );
+      (await prisma.externalUrl.findMany({
+        where: { reportId: id },
+        select: { id: true, url: true, label: true },
+      }));
 
     const item = {
       id: result.report.id,

--- a/front/src/app/api/reports/route.ts
+++ b/front/src/app/api/reports/route.ts
@@ -8,7 +8,10 @@ import { requireAdmin } from '@/lib/auth-server';
 type TagMapping = ReportTagMapping & { ReportTag: ReportTag };
 
 /** 一覧取得用の Report 行。本文（content）は省き、タグと外部 URL を結合した型。 */
-type ReportListRow = Omit<Report, 'content'> & { ReportTagMapping: TagMapping[]; ExternalUrl: ExternalUrl[] };
+type ReportListRow = Omit<Report, 'content'> & {
+  ReportTagMapping: TagMapping[];
+  ExternalUrl: ExternalUrl[];
+};
 
 /**
  * タグマッピングの配列からタグ名だけを取り出す。

--- a/front/src/app/api/tags/route.ts
+++ b/front/src/app/api/tags/route.ts
@@ -14,9 +14,12 @@ export async function GET() {
       orderBy: { name: 'asc' },
       select: { name: true },
     });
-    return NextResponse.json(tags.map((t) => t.name), {
-      headers: { 'Cache-Control': 's-maxage=60, stale-while-revalidate=300' },
-    });
+    return NextResponse.json(
+      tags.map((t) => t.name),
+      {
+        headers: { 'Cache-Control': 's-maxage=60, stale-while-revalidate=300' },
+      },
+    );
   } catch (error) {
     console.error('[api/tags] GET failed', error);
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 });

--- a/front/src/app/globals.css
+++ b/front/src/app/globals.css
@@ -1,5 +1,5 @@
 /* Report Viewer global styles (Markdown readability: Noto Sans JP headings + callouts) */
-@import "tailwindcss";
+@import 'tailwindcss';
 
 :root {
   --background: #faf7f5;
@@ -24,8 +24,7 @@ body {
 }
 
 .loading-gradient {
-  background:
-    radial-gradient(120% 120% at 50% 0%, #fff6ef 0%, #f3e7de 45%, #e2d5cb 100%);
+  background: radial-gradient(120% 120% at 50% 0%, #fff6ef 0%, #f3e7de 45%, #e2d5cb 100%);
 }
 
 .report-markdown {
@@ -134,7 +133,9 @@ body {
 }
 
 .report-markdown :where(code, pre) {
-  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+  font-family:
+    ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New',
+    monospace;
 }
 
 .report-markdown code {
@@ -437,7 +438,9 @@ body {
 }
 
 .report-markdown--v7 a[href^='http'] {
-  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+  font-family:
+    ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New',
+    monospace;
   font-size: 0.9em;
 }
 

--- a/front/src/components/__tests__/ConfirmationModal.test.tsx
+++ b/front/src/components/__tests__/ConfirmationModal.test.tsx
@@ -74,7 +74,9 @@ describe('ConfirmationModal', () => {
     let resolveConfirm!: () => void;
     const props = makeProps({
       onConfirm: vi.fn().mockReturnValue(
-        new Promise<void>((res) => { resolveConfirm = res; }),
+        new Promise<void>((res) => {
+          resolveConfirm = res;
+        }),
       ),
     });
     render(<ConfirmationModal {...props} />);
@@ -92,7 +94,9 @@ describe('ConfirmationModal', () => {
     let resolveConfirm!: () => void;
     const props = makeProps({
       onConfirm: vi.fn().mockReturnValue(
-        new Promise<void>((res) => { resolveConfirm = res; }),
+        new Promise<void>((res) => {
+          resolveConfirm = res;
+        }),
       ),
     });
     render(<ConfirmationModal {...props} />);
@@ -111,7 +115,9 @@ describe('ConfirmationModal', () => {
     const user = userEvent.setup();
     let resolveConfirm!: () => void;
     const onConfirm = vi.fn().mockReturnValue(
-      new Promise<void>((res) => { resolveConfirm = res; }),
+      new Promise<void>((res) => {
+        resolveConfirm = res;
+      }),
     );
     render(<ConfirmationModal {...makeProps({ onConfirm })} />);
 
@@ -153,7 +159,8 @@ describe('ConfirmationModal', () => {
 
   it('should allow retry after onConfirm error (M-A-2)', async () => {
     const user = userEvent.setup();
-    const onConfirm = vi.fn()
+    const onConfirm = vi
+      .fn()
       .mockRejectedValueOnce(new Error('First fail'))
       .mockResolvedValueOnce(undefined);
     const props = makeProps({ onConfirm });

--- a/front/src/components/atoms/Badge.tsx
+++ b/front/src/components/atoms/Badge.tsx
@@ -12,9 +12,7 @@ interface BadgeProps {
 /** カテゴリやステータスを示す小さなラベル用の最小 UI 部品。 */
 const Badge: React.FC<BadgeProps> = ({ children, className = '' }) => {
   return (
-    <span
-      className={`text-[10px] uppercase font-bold tracking-widest px-3 py-1 ${className}`}
-    >
+    <span className={`text-[10px] uppercase font-bold tracking-widest px-3 py-1 ${className}`}>
       {children}
     </span>
   );

--- a/front/src/components/atoms/Button.tsx
+++ b/front/src/components/atoms/Button.tsx
@@ -7,12 +7,7 @@ type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement>;
 
 /** 汎用ボタン。共通のトランジション/カーソル指定を付与し、残りの属性はそのまま透過する。 */
 const Button: React.FC<ButtonProps> = ({ className = '', ...props }) => {
-  return (
-    <button
-      className={`transition-all cursor-pointer ${className}`}
-      {...props}
-    />
-  );
+  return <button className={`transition-all cursor-pointer ${className}`} {...props} />;
 };
 
 export default Button;

--- a/front/src/components/atoms/Input.tsx
+++ b/front/src/components/atoms/Input.tsx
@@ -7,12 +7,7 @@ type InputProps = React.InputHTMLAttributes<HTMLInputElement>;
 
 /** 汎用テキスト入力。共通の基本スタイルを付与し、残りの属性はそのまま透過する。 */
 const Input: React.FC<InputProps> = ({ className = '', ...props }) => {
-  return (
-    <input
-      className={`w-full bg-white focus:outline-none ${className}`}
-      {...props}
-    />
-  );
+  return <input className={`w-full bg-white focus:outline-none ${className}`} {...props} />;
 };
 
 export default Input;

--- a/front/src/components/atoms/Select.tsx
+++ b/front/src/components/atoms/Select.tsx
@@ -8,10 +8,7 @@ type SelectProps = React.SelectHTMLAttributes<HTMLSelectElement>;
 /** 汎用セレクトボックス。共通の基本スタイルを付与し、残りの属性はそのまま透過する。 */
 const Select: React.FC<SelectProps> = ({ className = '', children, ...props }) => {
   return (
-    <select
-      className={`w-full bg-white focus:outline-none ${className}`}
-      {...props}
-    >
+    <select className={`w-full bg-white focus:outline-none ${className}`} {...props}>
       {children}
     </select>
   );

--- a/front/src/components/atoms/TextArea.tsx
+++ b/front/src/components/atoms/TextArea.tsx
@@ -7,12 +7,7 @@ type TextAreaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>;
 
 /** 汎用複数行入力。共通の基本スタイルを付与し、残りの属性はそのまま透過する。 */
 const TextArea: React.FC<TextAreaProps> = ({ className = '', ...props }) => {
-  return (
-    <textarea
-      className={`w-full bg-white focus:outline-none ${className}`}
-      {...props}
-    />
-  );
+  return <textarea className={`w-full bg-white focus:outline-none ${className}`} {...props} />;
 };
 
 export default TextArea;

--- a/front/src/components/molecules/AuthorInfo.tsx
+++ b/front/src/components/molecules/AuthorInfo.tsx
@@ -37,13 +37,13 @@ const AuthorInfo: React.FC<AuthorInfoProps> = ({
       <div>
         <span className={`block font-bold ${nameClassName}`}>{name}</span>
         {role && (
-          <span className={`block text-[10px] tracking-wider uppercase font-medium ${subtitleClassName}`}>
+          <span
+            className={`block text-[10px] tracking-wider uppercase font-medium ${subtitleClassName}`}
+          >
             {role}
           </span>
         )}
-        {subtitle && !role && (
-          <span className={`block ${subtitleClassName}`}>{subtitle}</span>
-        )}
+        {subtitle && !role && <span className={`block ${subtitleClassName}`}>{subtitle}</span>}
       </div>
     </div>
   );

--- a/front/src/components/molecules/ExternalUrlFieldList.tsx
+++ b/front/src/components/molecules/ExternalUrlFieldList.tsx
@@ -39,9 +39,7 @@ const ExternalUrlFieldList: React.FC<ExternalUrlFieldListProps> = ({
   borderRadiusClass,
 }) => (
   <div className="space-y-4">
-    <h3 className={`text-xs uppercase tracking-widest ${labelClassName ?? ''}`}>
-      External Links
-    </h3>
+    <h3 className={`text-xs uppercase tracking-widest ${labelClassName ?? ''}`}>External Links</h3>
     {urls.map((eu, i) => (
       <ExternalUrlInput
         key={i}

--- a/front/src/components/molecules/FilterIndicator.tsx
+++ b/front/src/components/molecules/FilterIndicator.tsx
@@ -31,12 +31,8 @@ const FilterIndicator: React.FC<FilterIndicatorProps> = ({
   return (
     <div className="flex flex-wrap items-center gap-3 text-xs uppercase tracking-widest">
       <span className={mutedClassName}>Filter</span>
-      {category && (
-        <span className={`px-2 py-1 border ${badgeClassName}`}>{category}</span>
-      )}
-      {tag && (
-        <span className={`px-2 py-1 border ${badgeClassName}`}>#{tag}</span>
-      )}
+      {category && <span className={`px-2 py-1 border ${badgeClassName}`}>{category}</span>}
+      {tag && <span className={`px-2 py-1 border ${badgeClassName}`}>#{tag}</span>}
       <Button
         type="button"
         onClick={onClear}

--- a/front/src/components/molecules/FormField.tsx
+++ b/front/src/components/molecules/FormField.tsx
@@ -16,17 +16,14 @@ interface FormFieldProps {
 
 /** ラベル＋入力＋エラーを縦に並べるフォーム部品。`useId` で採番した id を children に渡しラベルと入力を関連付ける。 */
 
-const FormField: React.FC<FormFieldProps> = ({
-  label,
-  labelClassName = '',
-  error,
-  children,
-}) => {
+const FormField: React.FC<FormFieldProps> = ({ label, labelClassName = '', error, children }) => {
   const id = useId();
 
   return (
     <div className="space-y-2">
-      <SectionLabel htmlFor={id} className={labelClassName}>{label}</SectionLabel>
+      <SectionLabel htmlFor={id} className={labelClassName}>
+        {label}
+      </SectionLabel>
       {children(id)}
       {error && <p className="text-xs text-red-700">{error}</p>}
     </div>

--- a/front/src/components/molecules/PaginationNav.tsx
+++ b/front/src/components/molecules/PaginationNav.tsx
@@ -47,7 +47,9 @@ const PaginationNav: React.FC<PaginationNavProps> = ({
         onClick={() => onPageChange(currentPage - 1)}
         disabled={currentPage === 1}
         className={`min-w-[4.5rem] px-3 py-2 text-sm border ${borderClassName} ${borderRadius} ${
-          currentPage === 1 ? 'opacity-40 cursor-not-allowed' : `${surfaceClassName} ${textClassName}`
+          currentPage === 1
+            ? 'opacity-40 cursor-not-allowed'
+            : `${surfaceClassName} ${textClassName}`
         }`}
       >
         前へ
@@ -74,7 +76,9 @@ const PaginationNav: React.FC<PaginationNavProps> = ({
         onClick={() => onPageChange(currentPage + 1)}
         disabled={currentPage === totalPages}
         className={`min-w-[4.5rem] px-3 py-2 text-sm border ${borderClassName} ${borderRadius} ${
-          currentPage === totalPages ? 'opacity-40 cursor-not-allowed' : `${surfaceClassName} ${textClassName}`
+          currentPage === totalPages
+            ? 'opacity-40 cursor-not-allowed'
+            : `${surfaceClassName} ${textClassName}`
         }`}
       >
         次へ

--- a/front/src/components/organisms/AppShell.tsx
+++ b/front/src/components/organisms/AppShell.tsx
@@ -100,14 +100,18 @@ const AppShell = ({ children }: { children: React.ReactNode }) => {
   }, []);
 
   return (
-    <div className={`${theme.colors.background} ${theme.fontPrimary} ${theme.colors.text} min-h-screen flex flex-col`}>
+    <div
+      className={`${theme.colors.background} ${theme.fontPrimary} ${theme.colors.text} min-h-screen flex flex-col`}
+    >
       <LoadingOverlay
         visible={showLoading}
         fadeOut={fadeOutLoading}
         onFadeOutEnd={() => setShowLoading(false)}
       />
       <LoadingProvider value={{ startLoading: triggerLoading }}>
-        <div className={`transition-opacity duration-700 ${isHydrated ? 'opacity-100' : 'opacity-0'}`}>
+        <div
+          className={`transition-opacity duration-700 ${isHydrated ? 'opacity-100' : 'opacity-0'}`}
+        >
           <Header theme={theme} user={currentUser} onLogout={logout} />
           <div className="flex flex-1 pt-24">
             <Sidebar

--- a/front/src/components/organisms/Footer.tsx
+++ b/front/src/components/organisms/Footer.tsx
@@ -20,15 +20,19 @@ const Footer: React.FC<FooterProps> = ({ theme }) => {
     <footer className={`${colors.surface} ${colors.border} border-t py-12 px-8 mt-auto`}>
       <div className="max-w-6xl mx-auto flex flex-col md:flex-row justify-between items-start gap-8">
         <div>
-          <div className={`${fontHeader} text-xl font-bold ${colors.primary} mb-2`}>Report Viewer</div>
+          <div className={`${fontHeader} text-xl font-bold ${colors.primary} mb-2`}>
+            Report Viewer
+          </div>
           <p className={`max-w-xs text-sm ${colors.muted}`}>
             このアプリケーションはレポートビューワーを目的としてます
           </p>
         </div>
       </div>
-      <div className={`max-w-6xl mx-auto mt-12 pt-8 border-t border-inherit text-center text-xs ${colors.muted}`}>
-        &copy; {new Date().getFullYear()} Report Viewer Systems. All rights reserved. Built with Passion for
-        Brown.
+      <div
+        className={`max-w-6xl mx-auto mt-12 pt-8 border-t border-inherit text-center text-xs ${colors.muted}`}
+      >
+        &copy; {new Date().getFullYear()} Report Viewer Systems. All rights reserved. Built with
+        Passion for Brown.
       </div>
     </footer>
   );

--- a/front/src/components/organisms/LoginForm.tsx
+++ b/front/src/components/organisms/LoginForm.tsx
@@ -37,19 +37,30 @@ const LoginForm: React.FC<LoginFormProps> = ({ theme, onLogin, onLoginWithGoogle
   const authMode = process.env.NEXT_PUBLIC_AUTH_MODE ?? 'supabase';
 
   return (
-    <div className={`min-h-screen flex items-center justify-center ${colors.background} ${colors.text} p-6`}>
+    <div
+      className={`min-h-screen flex items-center justify-center ${colors.background} ${colors.text} p-6`}
+    >
       <LoadingOverlay visible={isSubmitting} />
-      <div className={`w-full max-w-md bg-white border ${colors.border} p-12 shadow-2xl ${borderRadius}`}>
+      <div
+        className={`w-full max-w-md bg-white border ${colors.border} p-12 shadow-2xl ${borderRadius}`}
+      >
         <div className="text-center mb-10">
-          <h1 className={`${fontHeader} text-3xl font-bold ${colors.primary} mb-2`}>Report Viewer</h1>
-          <p className={`text-sm ${colors.muted} font-medium`}>レポート管理ダッシュボードへアクセス</p>
+          <h1 className={`${fontHeader} text-3xl font-bold ${colors.primary} mb-2`}>
+            Report Viewer
+          </h1>
+          <p className={`text-sm ${colors.muted} font-medium`}>
+            レポート管理ダッシュボードへアクセス
+          </p>
         </div>
 
         <form onSubmit={handleSubmit} className="space-y-6">
           {authMode === 'local' ? (
             <>
               <div className="space-y-2">
-                <label htmlFor="login-email" className={`block text-[10px] uppercase font-bold tracking-widest ${colors.text} opacity-80`}>
+                <label
+                  htmlFor="login-email"
+                  className={`block text-[10px] uppercase font-bold tracking-widest ${colors.text} opacity-80`}
+                >
                   Email
                 </label>
                 <input
@@ -63,7 +74,10 @@ const LoginForm: React.FC<LoginFormProps> = ({ theme, onLogin, onLoginWithGoogle
                 />
               </div>
               <div className="space-y-2">
-                <label htmlFor="login-password" className={`block text-[10px] uppercase font-bold tracking-widest ${colors.text} opacity-80`}>
+                <label
+                  htmlFor="login-password"
+                  className={`block text-[10px] uppercase font-bold tracking-widest ${colors.text} opacity-80`}
+                >
                   Password
                 </label>
                 <input

--- a/front/src/components/organisms/ReportMarkdown.tsx
+++ b/front/src/components/organisms/ReportMarkdown.tsx
@@ -143,7 +143,11 @@ const markdownComponents: Components = {
  * @param content - 描画対象の Markdown 断片
  */
 const renderMarkdown = (content: string) => (
-  <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeSanitize]} components={markdownComponents}>
+  <ReactMarkdown
+    remarkPlugins={[remarkGfm]}
+    rehypePlugins={[rehypeSanitize]}
+    components={markdownComponents}
+  >
     {content}
   </ReactMarkdown>
 );
@@ -162,7 +166,11 @@ const CALLOUT_CLASS: Record<Exclude<SectionKind, 'normal'>, string> = {
  * セクションはコールアウト（強調ボックス）で囲んで描画する。描画はすべて `rehypeSanitize`
  * 経由でサニタイズされる。
  */
-const ReportMarkdown: React.FC<ReportMarkdownProps> = ({ content, variant = 'v7', className = '' }) => {
+const ReportMarkdown: React.FC<ReportMarkdownProps> = ({
+  content,
+  variant = 'v7',
+  className = '',
+}) => {
   const sections = splitSections(content);
 
   return (

--- a/front/src/components/organisms/Sidebar.tsx
+++ b/front/src/components/organisms/Sidebar.tsx
@@ -41,9 +41,7 @@ const Sidebar: React.FC<SidebarProps> = ({
   // 比較・選択判定用の値: 大文字小文字を無視するため小文字化する
   const normalizeTagValue = (tag: string) => normalizeTag(tag).toLowerCase();
   // 正規化後の表示ラベルで重複排除し、ラベル（表示用）と value（判定用）の組へ整形する
-  const visibleTags = Array.from(
-    new Set(tags.map(normalizeTag).filter(Boolean)),
-  ).map((tag) => ({
+  const visibleTags = Array.from(new Set(tags.map(normalizeTag).filter(Boolean))).map((tag) => ({
     label: tag,
     value: normalizeTagValue(tag),
   }));

--- a/front/src/components/pages/DetailPage.tsx
+++ b/front/src/components/pages/DetailPage.tsx
@@ -31,9 +31,7 @@ const DetailPage: React.FC<DetailPageProps> = ({ theme, report, user, onDelete }
   const [deleteError, setDeleteError] = useState<string | null>(null);
   const { colors, fontHeader, fontPrimary, borderRadius } = theme;
   // publishDate を優先し、無ければ createdAt を使い、ISO の日付部分のみ表示する。
-  const displayDate = report
-    ? (report.publishDate || report.createdAt || '').split('T')[0]
-    : '';
+  const displayDate = report ? (report.publishDate || report.createdAt || '').split('T')[0] : '';
   // 著者名はログイン中ユーザー名に統一（未ログイン時は 'Manager'）。単一管理者運用のため。
   const displayAuthor = user?.username ?? 'Manager';
 
@@ -52,7 +50,10 @@ const DetailPage: React.FC<DetailPageProps> = ({ theme, report, user, onDelete }
     <article className="max-w-4xl mx-auto p-8 md:p-12">
       <div className="mb-12">
         <div className="flex items-center gap-3 mb-6">
-          <AppLink href="/" className={`text-sm ${colors.muted} hover:opacity-70 transition-opacity`}>
+          <AppLink
+            href="/"
+            className={`text-sm ${colors.muted} hover:opacity-70 transition-opacity`}
+          >
             &larr; All Reports
           </AppLink>
           <span className="opacity-20">|</span>
@@ -63,7 +64,9 @@ const DetailPage: React.FC<DetailPageProps> = ({ theme, report, user, onDelete }
           </span>
         </div>
 
-        <h1 className={`${fontHeader} text-4xl md:text-6xl font-black ${colors.primary} mb-8 leading-tight`}>
+        <h1
+          className={`${fontHeader} text-4xl md:text-6xl font-black ${colors.primary} mb-8 leading-tight`}
+        >
           {report.title}
         </h1>
 
@@ -121,10 +124,15 @@ const DetailPage: React.FC<DetailPageProps> = ({ theme, report, user, onDelete }
       )}
 
       <div className="mt-16 pt-12 border-t border-inherit">
-        <h4 className={`${fontHeader} text-xs uppercase tracking-widest ${colors.muted} mb-4`}>Tags</h4>
+        <h4 className={`${fontHeader} text-xs uppercase tracking-widest ${colors.muted} mb-4`}>
+          Tags
+        </h4>
         <div className="flex gap-2">
           {report.tags.map((tag) => (
-            <span key={tag} className={`text-[10px] px-3 py-1 bg-neutral-200 ${colors.text} ${borderRadius}`}>
+            <span
+              key={tag}
+              className={`text-[10px] px-3 py-1 bg-neutral-200 ${colors.text} ${borderRadius}`}
+            >
               {tag}
             </span>
           ))}

--- a/front/src/components/pages/FormPage.tsx
+++ b/front/src/components/pages/FormPage.tsx
@@ -90,7 +90,11 @@ const FormPage: React.FC<FormPageProps> = ({
         </FormField>
 
         <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
-          <FormField label="カテゴリー" labelClassName={fieldLabelClass} error={fieldErrors.category}>
+          <FormField
+            label="カテゴリー"
+            labelClassName={fieldLabelClass}
+            error={fieldErrors.category}
+          >
             {(id) => (
               <select
                 id={id}
@@ -107,7 +111,11 @@ const FormPage: React.FC<FormPageProps> = ({
               </select>
             )}
           </FormField>
-          <FormField label="タグ (カンマ区切り)" labelClassName={fieldLabelClass} error={tagError || fieldErrors.tags}>
+          <FormField
+            label="タグ (カンマ区切り)"
+            labelClassName={fieldLabelClass}
+            error={tagError || fieldErrors.tags}
+          >
             {(id) => (
               <input
                 id={id}
@@ -136,7 +144,11 @@ const FormPage: React.FC<FormPageProps> = ({
           )}
         </FormField>
 
-        <FormField label="本文 (Markdown)" labelClassName={fieldLabelClass} error={fieldErrors.content}>
+        <FormField
+          label="本文 (Markdown)"
+          labelClassName={fieldLabelClass}
+          error={fieldErrors.content}
+        >
           {(id) => (
             <textarea
               id={id}

--- a/front/src/components/pages/ListPage.tsx
+++ b/front/src/components/pages/ListPage.tsx
@@ -24,7 +24,8 @@ interface ListPageProps {
  */
 const ListPage: React.FC<ListPageProps> = ({ theme, reports }) => {
   const { colors, fontHeader, fontPrimary, borderRadius } = theme;
-  const { selectedCategory, selectedTag, setSelectedCategory, setSelectedTag, currentUser } = useAppState();
+  const { selectedCategory, selectedTag, setSelectedCategory, setSelectedTag, currentUser } =
+    useAppState();
 
   // 一覧画面に入るたびに前回のフィルタ選択を解除し、常に全件表示から始める。
   // （サイドバー等でのフィルタ状態はグローバルに持続するため、ここでリセットする）
@@ -52,8 +53,10 @@ const ListPage: React.FC<ListPageProps> = ({ theme, reports }) => {
   // フィルタ条件が変わったらページネーションを1ページ目へ戻すためのキー。
   // このキーの変化を usePagination が検知して現在ページをリセットする。
   const filterKey = `${selectedCategory ?? ''}|${selectedTag ?? ''}`;
-  const { currentPage, totalPages, pageNumbers, updatePage, paginateSlice } =
-    usePagination(visibleReports.length, filterKey);
+  const { currentPage, totalPages, pageNumbers, updatePage, paginateSlice } = usePagination(
+    visibleReports.length,
+    filterKey,
+  );
   const paginatedReports = paginateSlice(visibleReports);
 
   /**
@@ -101,10 +104,14 @@ const ListPage: React.FC<ListPageProps> = ({ theme, reports }) => {
                 badgeClassName={`${colors.accent} text-white ${borderRadius}`}
                 dateClassName={colors.muted}
               />
-              <h2 className={`${fontHeader} text-2xl font-bold ${colors.text} mb-4 leading-tight group-hover:underline`}>
+              <h2
+                className={`${fontHeader} text-2xl font-bold ${colors.text} mb-4 leading-tight group-hover:underline`}
+              >
                 <AppLink href={`/report/${report.id}`}>{report.title}</AppLink>
               </h2>
-              <p className={`${fontPrimary} ${colors.text} opacity-80 mb-8 line-clamp-3 leading-relaxed`}>
+              <p
+                className={`${fontPrimary} ${colors.text} opacity-80 mb-8 line-clamp-3 leading-relaxed`}
+              >
                 {report.summary}
               </p>
               <div className="flex items-center justify-between border-t pt-6 border-inherit">

--- a/front/src/components/pages/MarkdownLabPage.tsx
+++ b/front/src/components/pages/MarkdownLabPage.tsx
@@ -97,19 +97,26 @@ const MarkdownLabPage: React.FC<MarkdownLabPageProps> = ({ theme }) => {
         <AppLink href="/" className={`text-sm ${colors.muted} transition-opacity hover:opacity-70`}>
           &larr; All Reports
         </AppLink>
-        <h1 className={`${fontHeader} ${colors.primary} mt-4 text-4xl font-black leading-tight md:text-5xl`}>
+        <h1
+          className={`${fontHeader} ${colors.primary} mt-4 text-4xl font-black leading-tight md:text-5xl`}
+        >
           Markdown Style Lab
         </h1>
         <p className={`${colors.muted} mt-4 max-w-3xl text-sm leading-relaxed md:text-base`}>
-          Pattern 07 is the active baseline for tuning. Font families and palette remain fixed to the current theme.
+          Pattern 07 is the active baseline for tuning. Font families and palette remain fixed to
+          the current theme.
         </p>
       </div>
 
       <div className="mx-auto max-w-5xl">
-        <article className={`${colors.surface} ${colors.border} ${borderRadius} border p-5 shadow-sm md:p-6`}>
+        <article
+          className={`${colors.surface} ${colors.border} ${borderRadius} border p-5 shadow-sm md:p-6`}
+        >
           <header className={`mb-5 border-b ${colors.border} pb-4`}>
             <p className={`${colors.muted} text-[11px] uppercase tracking-[0.2em]`}>Pattern 07</p>
-            <h2 className={`${fontHeader} ${colors.primary} mt-2 text-2xl font-bold`}>{ACTIVE_VARIANT.label}</h2>
+            <h2 className={`${fontHeader} ${colors.primary} mt-2 text-2xl font-bold`}>
+              {ACTIVE_VARIANT.label}
+            </h2>
             <p className={`${colors.muted} mt-2 text-sm leading-relaxed`}>{ACTIVE_VARIANT.note}</p>
           </header>
 

--- a/front/src/constants.ts
+++ b/front/src/constants.ts
@@ -36,7 +36,16 @@ export const ESPRESSO_THEME: DesignSystem = {
  * この配列を参照して検証するため、ここが唯一の正準リスト。増減時は本定数のみ
  * 変更すれば API バリデーションと OpenAPI 生成に伝播する。
  */
-export const CATEGORIES = ['Development', 'AI', 'Cloud', 'Linux', 'Container', 'Application', 'Program', 'Hobby'];
+export const CATEGORIES = [
+  'Development',
+  'AI',
+  'Cloud',
+  'Linux',
+  'Container',
+  'Application',
+  'Program',
+  'Hobby',
+];
 
 /** サイドバー等に表示する「トレンドタグ」の見せ球（固定表示。実データ集計ではない）。 */
 export const TRENDING_TAGS = ['#AI', '#UIUX', '#Minimal', '#Nature'];

--- a/front/src/hooks/__tests__/usePagination.test.ts
+++ b/front/src/hooks/__tests__/usePagination.test.ts
@@ -51,10 +51,9 @@ describe('usePagination', () => {
   });
 
   it('should reset to page 1 when filterKey changes (P-S-2)', () => {
-    const { result, rerender } = renderHook(
-      ({ filterKey }) => usePagination(50, filterKey),
-      { initialProps: { filterKey: 'AI' } },
-    );
+    const { result, rerender } = renderHook(({ filterKey }) => usePagination(50, filterKey), {
+      initialProps: { filterKey: 'AI' },
+    });
     act(() => result.current.updatePage(3));
     expect(result.current.currentPage).toBe(3);
 
@@ -75,10 +74,9 @@ describe('usePagination', () => {
   });
 
   it('should adjust currentPage when totalItems decreases (P-S-5)', () => {
-    const { result, rerender } = renderHook(
-      ({ total }) => usePagination(total, 'all'),
-      { initialProps: { total: 50 } },
-    );
+    const { result, rerender } = renderHook(({ total }) => usePagination(total, 'all'), {
+      initialProps: { total: 50 },
+    });
     act(() => result.current.updatePage(5));
     expect(result.current.currentPage).toBe(5);
 

--- a/front/src/hooks/__tests__/useReportForm.test.ts
+++ b/front/src/hooks/__tests__/useReportForm.test.ts
@@ -22,9 +22,7 @@ const testReport: ReportItem = {
   author: 'Editor',
   publishDate: '2024-01-15',
   tags: ['#AI', '#Cloud'],
-  externalUrls: [
-    { id: 'eu1', url: 'https://example.com', label: 'Example' },
-  ],
+  externalUrls: [{ id: 'eu1', url: 'https://example.com', label: 'Example' }],
 };
 
 // 安定参照の fixture（edit モードのテストで effect 依存を安定させる）
@@ -41,9 +39,7 @@ describe('useReportForm', () => {
   // --- 正常系 ---
 
   it('should initialize with defaults in add mode (RF-N-1)', () => {
-    const { result } = renderHook(() =>
-      useReportForm({ user: testUser, onSubmit: mockOnSubmit }),
-    );
+    const { result } = renderHook(() => useReportForm({ user: testUser, onSubmit: mockOnSubmit }));
     expect(result.current.formData.category).toBe('Development');
     expect(result.current.formData.author).toBe('Editor');
     expect(result.current.externalUrls).toEqual([]);
@@ -63,9 +59,7 @@ describe('useReportForm', () => {
   });
 
   it('should update formData on handleChange (RF-N-3)', () => {
-    const { result } = renderHook(() =>
-      useReportForm({ user: testUser, onSubmit: mockOnSubmit }),
-    );
+    const { result } = renderHook(() => useReportForm({ user: testUser, onSubmit: mockOnSubmit }));
     act(() => {
       result.current.handleChange({
         target: { name: 'title', value: 'New Title' },
@@ -75,9 +69,7 @@ describe('useReportForm', () => {
   });
 
   it('should normalize tags on handleTagsChange (RF-N-4)', () => {
-    const { result } = renderHook(() =>
-      useReportForm({ user: testUser, onSubmit: mockOnSubmit }),
-    );
+    const { result } = renderHook(() => useReportForm({ user: testUser, onSubmit: mockOnSubmit }));
     act(() => {
       result.current.handleTagsChange({
         target: { value: 'ai, cloud' },
@@ -87,9 +79,7 @@ describe('useReportForm', () => {
   });
 
   it('should show confirm modal when tags are present (RF-N-5)', () => {
-    const { result } = renderHook(() =>
-      useReportForm({ user: testUser, onSubmit: mockOnSubmit }),
-    );
+    const { result } = renderHook(() => useReportForm({ user: testUser, onSubmit: mockOnSubmit }));
     act(() => {
       result.current.handleTagsChange({
         target: { value: 'test' },
@@ -102,9 +92,7 @@ describe('useReportForm', () => {
   });
 
   it('should call onSubmit on handleConfirmSubmit (RF-N-6)', async () => {
-    const { result } = renderHook(() =>
-      useReportForm({ user: testUser, onSubmit: mockOnSubmit }),
-    );
+    const { result } = renderHook(() => useReportForm({ user: testUser, onSubmit: mockOnSubmit }));
     act(() => {
       result.current.handleTagsChange({
         target: { value: 'test' },
@@ -117,9 +105,7 @@ describe('useReportForm', () => {
   });
 
   it('should add, update, and remove external URLs (RF-N-7)', () => {
-    const { result } = renderHook(() =>
-      useReportForm({ user: testUser, onSubmit: mockOnSubmit }),
-    );
+    const { result } = renderHook(() => useReportForm({ user: testUser, onSubmit: mockOnSubmit }));
     act(() => result.current.addExternalUrl());
     expect(result.current.externalUrls).toHaveLength(1);
 
@@ -139,24 +125,18 @@ describe('useReportForm', () => {
         onSubmit: mockOnSubmit,
       }),
     );
-    expect(result.current.externalUrls).toEqual([
-      { url: 'https://example.com', label: 'Example' },
-    ]);
+    expect(result.current.externalUrls).toEqual([{ url: 'https://example.com', label: 'Example' }]);
   });
 
   // --- 準正常系 ---
 
   it('should redirect to /login when user is null (RF-S-1)', () => {
-    renderHook(() =>
-      useReportForm({ user: null, onSubmit: mockOnSubmit }),
-    );
+    renderHook(() => useReportForm({ user: null, onSubmit: mockOnSubmit }));
     expect(mockPush).toHaveBeenCalledWith('/login');
   });
 
   it('should show tag error when tags are empty on submit (RF-S-2)', () => {
-    const { result } = renderHook(() =>
-      useReportForm({ user: testUser, onSubmit: mockOnSubmit }),
-    );
+    const { result } = renderHook(() => useReportForm({ user: testUser, onSubmit: mockOnSubmit }));
     act(() => {
       result.current.handleSubmitAttempt({ preventDefault: vi.fn() } as unknown as React.FormEvent);
     });
@@ -165,9 +145,7 @@ describe('useReportForm', () => {
   });
 
   it('should clear tag error when tags are added (RF-S-3)', () => {
-    const { result } = renderHook(() =>
-      useReportForm({ user: testUser, onSubmit: mockOnSubmit }),
-    );
+    const { result } = renderHook(() => useReportForm({ user: testUser, onSubmit: mockOnSubmit }));
     act(() => {
       result.current.handleSubmitAttempt({ preventDefault: vi.fn() } as unknown as React.FormEvent);
     });
@@ -189,9 +167,7 @@ describe('useReportForm', () => {
       fieldErrors: { title: 'エラー' },
     });
 
-    const { result } = renderHook(() =>
-      useReportForm({ user: testUser, onSubmit: mockOnSubmit }),
-    );
+    const { result } = renderHook(() => useReportForm({ user: testUser, onSubmit: mockOnSubmit }));
     act(() => {
       result.current.handleTagsChange({
         target: { value: 'test' },
@@ -211,9 +187,7 @@ describe('useReportForm', () => {
   });
 
   it('should validate external URLs on confirm submit (RF-S-5)', async () => {
-    const { result } = renderHook(() =>
-      useReportForm({ user: testUser, onSubmit: mockOnSubmit }),
-    );
+    const { result } = renderHook(() => useReportForm({ user: testUser, onSubmit: mockOnSubmit }));
     act(() => {
       result.current.handleTagsChange({
         target: { value: 'test' },
@@ -232,9 +206,7 @@ describe('useReportForm', () => {
   it('should redirect to /login on 401 response (RF-S-6)', async () => {
     mockOnSubmit.mockResolvedValueOnce({ ok: false, status: 401, error: 'Unauthorized' });
 
-    const { result } = renderHook(() =>
-      useReportForm({ user: testUser, onSubmit: mockOnSubmit }),
-    );
+    const { result } = renderHook(() => useReportForm({ user: testUser, onSubmit: mockOnSubmit }));
     act(() => {
       result.current.handleTagsChange({
         target: { value: 'test' },
@@ -254,9 +226,7 @@ describe('useReportForm', () => {
       fieldErrors: { content: '本文エラー' },
     });
 
-    const { result } = renderHook(() =>
-      useReportForm({ user: testUser, onSubmit: mockOnSubmit }),
-    );
+    const { result } = renderHook(() => useReportForm({ user: testUser, onSubmit: mockOnSubmit }));
     act(() => {
       result.current.handleTagsChange({
         target: { value: 'test' },
@@ -275,9 +245,7 @@ describe('useReportForm', () => {
       error: 'Server Error',
     });
 
-    const { result } = renderHook(() =>
-      useReportForm({ user: testUser, onSubmit: mockOnSubmit }),
-    );
+    const { result } = renderHook(() => useReportForm({ user: testUser, onSubmit: mockOnSubmit }));
     act(() => {
       result.current.handleTagsChange({
         target: { value: 'test' },
@@ -290,9 +258,7 @@ describe('useReportForm', () => {
   });
 
   it('should re-index field errors after removeExternalUrl (RF-S-9)', async () => {
-    const { result } = renderHook(() =>
-      useReportForm({ user: testUser, onSubmit: mockOnSubmit }),
-    );
+    const { result } = renderHook(() => useReportForm({ user: testUser, onSubmit: mockOnSubmit }));
     act(() => {
       result.current.addExternalUrl();
       result.current.addExternalUrl();
@@ -325,9 +291,7 @@ describe('useReportForm', () => {
   it('should redirect to /login on 403 response (RF-A-1)', async () => {
     mockOnSubmit.mockResolvedValueOnce({ ok: false, status: 403, error: 'Forbidden' });
 
-    const { result } = renderHook(() =>
-      useReportForm({ user: testUser, onSubmit: mockOnSubmit }),
-    );
+    const { result } = renderHook(() => useReportForm({ user: testUser, onSubmit: mockOnSubmit }));
     act(() => {
       result.current.handleTagsChange({
         target: { value: 'test' },
@@ -340,9 +304,7 @@ describe('useReportForm', () => {
   });
 
   it('should not run effects when isHydrated is false (RF-A-2)', () => {
-    renderHook(() =>
-      useReportForm({ user: null, onSubmit: mockOnSubmit, isHydrated: false }),
-    );
+    renderHook(() => useReportForm({ user: null, onSubmit: mockOnSubmit, isHydrated: false }));
     expect(mockPush).not.toHaveBeenCalled();
   });
 });

--- a/front/src/hooks/usePagination.ts
+++ b/front/src/hooks/usePagination.ts
@@ -59,7 +59,10 @@ export const usePagination = (
     Math.min(currentPage - Math.floor(maxPageButtons / 2), safeTotalPages - maxPageButtons + 1),
   );
   const pageEnd = Math.min(safeTotalPages, pageStart + maxPageButtons - 1);
-  const pageNumbers = Array.from({ length: pageEnd - pageStart + 1 }, (_, index) => pageStart + index);
+  const pageNumbers = Array.from(
+    { length: pageEnd - pageStart + 1 },
+    (_, index) => pageStart + index,
+  );
 
   /**
    * 表示ページを更新する。範囲外の値は [1, 総ページ数] にクランプする。
@@ -79,7 +82,7 @@ export const usePagination = (
    * @param items ページングしたい全アイテム配列
    * @returns 現在ページに対応する要素のみを含む配列
    */
-  const paginateSlice = <T,>(items: T[]): T[] => {
+  const paginateSlice = <T>(items: T[]): T[] => {
     return items.slice((currentPage - 1) * itemsPerPage, currentPage * itemsPerPage);
   };
 

--- a/front/src/hooks/useReportForm.ts
+++ b/front/src/hooks/useReportForm.ts
@@ -165,8 +165,7 @@ export const useReportForm = ({
   };
 
   // 空の外部URL入力行を 1 つ追加する。
-  const addExternalUrl = () =>
-    setExternalUrls((prev) => [...prev, { url: '', label: '' }]);
+  const addExternalUrl = () => setExternalUrls((prev) => [...prev, { url: '', label: '' }]);
 
   /**
    * 指定インデックスの外部URL行を削除する。

--- a/front/src/lib/__tests__/validation.test.ts
+++ b/front/src/lib/__tests__/validation.test.ts
@@ -52,12 +52,13 @@ describe('validateReportInput', () => {
     expect(data.tags).toEqual([]);
   });
 
-  it.each([
-    'Development', 'AI', 'Cloud', 'Linux', 'Container', 'Application', 'Program', 'Hobby',
-  ])('should accept category "%s" (N-7)', (category) => {
-    const { errors } = validateReportInput({ ...validInput, category });
-    expect(errors.category).toBeUndefined();
-  });
+  it.each(['Development', 'AI', 'Cloud', 'Linux', 'Container', 'Application', 'Program', 'Hobby'])(
+    'should accept category "%s" (N-7)',
+    (category) => {
+      const { errors } = validateReportInput({ ...validInput, category });
+      expect(errors.category).toBeUndefined();
+    },
+  );
 
   // --- 準正常系 ---
 
@@ -212,9 +213,7 @@ describe('validateExternalUrls', () => {
   });
 
   it('should error when label exceeds 200 chars (EU-S-3)', () => {
-    const { errors } = validateExternalUrls([
-      { url: 'https://x.com', label: 'a'.repeat(201) },
-    ]);
+    const { errors } = validateExternalUrls([{ url: 'https://x.com', label: 'a'.repeat(201) }]);
     expect(errors['externalUrls.0.label']).toContain('200文字以内');
   });
 

--- a/front/src/lib/schemas/report.ts
+++ b/front/src/lib/schemas/report.ts
@@ -88,7 +88,12 @@ const titleSchema = z
       .min(1, 'タイトルは必須です。')
       .max(LIMITS.title, `タイトルは${LIMITS.title}文字以内です。`),
   )
-  .meta({ type: 'string', description: 'レポートタイトル', example: 'Kubernetes 入門', maxLength: LIMITS.title });
+  .meta({
+    type: 'string',
+    description: 'レポートタイトル',
+    example: 'Kubernetes 入門',
+    maxLength: LIMITS.title,
+  });
 
 const contentSchema = z
   .preprocess(
@@ -98,7 +103,12 @@ const contentSchema = z
       .min(1, '本文は必須です。')
       .max(LIMITS.content, `本文は${LIMITS.content}文字以内です。`),
   )
-  .meta({ type: 'string', description: 'Markdown 本文', example: '# 見出し\\n\\n本文', maxLength: LIMITS.content });
+  .meta({
+    type: 'string',
+    description: 'Markdown 本文',
+    example: '# 見出し\\n\\n本文',
+    maxLength: LIMITS.content,
+  });
 
 const authorSchema = z
   .preprocess(toStringValue, z.string().min(1, '著者は必須です。'))
@@ -122,10 +132,18 @@ const categorySchema = z
   });
 
 const summarySchema = z
-  .preprocess(toStringValue, z.string().max(LIMITS.summary, `要約は${LIMITS.summary}文字以内です。`))
+  .preprocess(
+    toStringValue,
+    z.string().max(LIMITS.summary, `要約は${LIMITS.summary}文字以内です。`),
+  )
   // 空文字は null に正規化する
   .transform((value) => (value ? value : null))
-  .meta({ type: 'string', description: '要約（空文字は null）', example: '記事の要約', maxLength: LIMITS.summary });
+  .meta({
+    type: 'string',
+    description: '要約（空文字は null）',
+    example: '記事の要約',
+    maxLength: LIMITS.summary,
+  });
 
 const publishDateSchema = z
   .preprocess(parsePublishDate, z.union([z.date(), z.null()]).optional())
@@ -158,7 +176,12 @@ const tagsCreateSchema = z
         message: `タグは${LIMITS.tag}文字以内です。`,
       }),
   )
-  .meta({ type: 'array', items: { type: 'string' }, description: 'タグ（`#` 付き canonical）', example: ['#AI', '#Cloud'] });
+  .meta({
+    type: 'array',
+    items: { type: 'string' },
+    description: 'タグ（`#` 付き canonical）',
+    example: ['#AI', '#Cloud'],
+  });
 
 /** 更新: タグは省略可・空配列可。 */
 const tagsPatchSchema = tagsBaseSchema.meta({
@@ -174,11 +197,17 @@ export const externalUrlInputSchema = z
     url: z
       .preprocess(
         toStringValue,
-        z.string().min(1, 'URLは必須です。').regex(URL_PATTERN, 'URLはhttp://またはhttps://で始まる必要があります。'),
+        z
+          .string()
+          .min(1, 'URLは必須です。')
+          .regex(URL_PATTERN, 'URLはhttp://またはhttps://で始まる必要があります。'),
       )
       .meta({ type: 'string', format: 'uri', example: 'https://example.com' }),
     label: z
-      .preprocess(toStringValue, z.string().max(LIMITS.label, `ラベルは${LIMITS.label}文字以内です。`))
+      .preprocess(
+        toStringValue,
+        z.string().max(LIMITS.label, `ラベルは${LIMITS.label}文字以内です。`),
+      )
       .meta({ type: 'string', example: 'Example', maxLength: LIMITS.label }),
   })
   // preprocess により入力型が unknown になるため、必須フィールドを明示する
@@ -236,7 +265,10 @@ export const reportItemSchema = z
     content: z.string().meta({ description: '一覧 API では空文字' }),
     category: z.string().meta({ example: 'AI' }),
     author: z.string().meta({ example: 'Editor' }),
-    publishDate: z.string().nullable().meta({ format: 'date-time', example: '2024-01-15T00:00:00.000Z' }),
+    publishDate: z
+      .string()
+      .nullable()
+      .meta({ format: 'date-time', example: '2024-01-15T00:00:00.000Z' }),
     createdAt: z.string().meta({ format: 'date-time' }),
     updatedAt: z.string().meta({ format: 'date-time' }),
     tags: z.array(z.string()).meta({ example: ['#AI', '#Cloud'] }),
@@ -245,7 +277,9 @@ export const reportItemSchema = z
   .meta({ id: 'ReportItem' });
 
 /** タグ名の配列（レスポンス）。 */
-export const tagListSchema = z.array(z.string()).meta({ id: 'TagList', example: ['#AI', '#Cloud'] });
+export const tagListSchema = z
+  .array(z.string())
+  .meta({ id: 'TagList', example: ['#AI', '#Cloud'] });
 
 /** バリデーションエラーレスポンス（フィールド名 → 日本語メッセージ）。 */
 export const validationErrorSchema = z

--- a/front/src/lib/validation.ts
+++ b/front/src/lib/validation.ts
@@ -1,10 +1,5 @@
 import type { ExternalUrlInput } from '@/types';
-import {
-  LIMITS,
-  normalizeTags,
-  reportCreateSchema,
-  reportPatchSchema,
-} from '@/lib/schemas/report';
+import { LIMITS, normalizeTags, reportCreateSchema, reportPatchSchema } from '@/lib/schemas/report';
 
 /**
  * ランタイム検証アダプタ。

--- a/front/tests/e2e/app.spec.ts
+++ b/front/tests/e2e/app.spec.ts
@@ -1,10 +1,5 @@
 import { expect, test } from '@playwright/test';
-import {
-  reportsFixture,
-  pagedReportsFixture,
-  userFixture,
-  setStorage,
-} from './helpers';
+import { reportsFixture, pagedReportsFixture, userFixture, setStorage } from './helpers';
 
 test.describe('Reports app', () => {
   test('TC-001/002: list displays reports and navigates to detail', async ({ page }) => {
@@ -83,10 +78,16 @@ test.describe('Reports app', () => {
 
     await expect(pageNumberButtons).toHaveCount(5);
     await page.getByRole('button', { name: '5', exact: true }).click();
-    await expect(page.getByRole('button', { name: '5', exact: true })).toHaveAttribute('aria-current', 'page');
+    await expect(page.getByRole('button', { name: '5', exact: true })).toHaveAttribute(
+      'aria-current',
+      'page',
+    );
 
     await page.getByRole('button', { name: '次へ' }).click();
-    await expect(page.getByRole('button', { name: '6', exact: true })).toHaveAttribute('aria-current', 'page');
+    await expect(page.getByRole('button', { name: '6', exact: true })).toHaveAttribute(
+      'aria-current',
+      'page',
+    );
     await expect(page.getByRole('button', { name: '次へ' })).toBeDisabled();
     await expect(pageNumberButtons).toHaveCount(5);
   });
@@ -96,18 +97,26 @@ test.describe('Reports app', () => {
     await page.goto('/');
 
     await page.getByRole('button', { name: '次へ' }).click();
-    await expect(page.getByRole('button', { name: '2', exact: true })).toHaveAttribute('aria-current', 'page');
+    await expect(page.getByRole('button', { name: '2', exact: true })).toHaveAttribute(
+      'aria-current',
+      'page',
+    );
 
     const sidebar = page.locator('aside');
     const categorySection = sidebar.getByRole('heading', { name: 'Categories' }).locator('..');
     await categorySection.getByRole('button', { name: 'AI', exact: true }).click();
 
-    await expect(page.getByRole('button', { name: '1', exact: true })).toHaveAttribute('aria-current', 'page');
+    await expect(page.getByRole('button', { name: '1', exact: true })).toHaveAttribute(
+      'aria-current',
+      'page',
+    );
     await expect(page.getByRole('link', { name: 'Paged Report 2', exact: true })).toBeVisible();
     await expect(page.getByRole('link', { name: 'Paged Report 22', exact: true })).toHaveCount(0);
   });
 
-  test('TC-004/005/006: detail view handles valid/invalid and hides admin controls', async ({ page }) => {
+  test('TC-004/005/006: detail view handles valid/invalid and hides admin controls', async ({
+    page,
+  }) => {
     await setStorage(page, { reports: reportsFixture, user: null });
 
     await page.goto('/report/1');
@@ -148,7 +157,9 @@ test.describe('Reports app', () => {
     await expect(page).toHaveURL(/\/login$/);
   });
 
-  test('TC-011/012/013/014: create report with validation and tag normalization', async ({ page }) => {
+  test('TC-011/012/013/014: create report with validation and tag normalization', async ({
+    page,
+  }) => {
     await setStorage(page, { reports: reportsFixture, user: userFixture });
     await page.goto('/report/new');
 
@@ -185,7 +196,9 @@ test.describe('Reports app', () => {
     await page.goto('/report/1/edit');
 
     await expect(page.locator('input[name="title"]')).toHaveValue('Sample Report One');
-    await expect(page.locator('textarea[name="summary"]')).toHaveValue('Summary for sample report one.');
+    await expect(page.locator('textarea[name="summary"]')).toHaveValue(
+      'Summary for sample report one.',
+    );
 
     await page.locator('textarea[name="content"]').fill('# Heading\n\nUpdated content.');
     await page.getByRole('button', { name: '変更を保存' }).click();
@@ -230,7 +243,9 @@ test.describe('Reports app', () => {
     await expect(page.getByRole('link', { name: '編集' })).toHaveCount(0);
   });
 
-  test('TC-021/022: markdown lab requires auth and is reachable from header menu', async ({ page }) => {
+  test('TC-021/022: markdown lab requires auth and is reachable from header menu', async ({
+    page,
+  }) => {
     await setStorage(page, { reports: reportsFixture, user: userFixture });
 
     await page.goto('/report/markdown-lab');

--- a/front/tests/integration/auth.test.ts
+++ b/front/tests/integration/auth.test.ts
@@ -13,13 +13,17 @@ describe('GET /api/auth/admin (integration)', () => {
   });
 
   it('正常: 管理者トークンは {isAdmin:true}', async () => {
-    const res = await adminGet(makeRequest('http://localhost/api/auth/admin', { token: ADMIN_TOKEN }));
+    const res = await adminGet(
+      makeRequest('http://localhost/api/auth/admin', { token: ADMIN_TOKEN }),
+    );
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ isAdmin: true });
   });
 
   it('準正常: 非管理者トークンは {isAdmin:false}（200）', async () => {
-    const res = await adminGet(makeRequest('http://localhost/api/auth/admin', { token: USER_TOKEN }));
+    const res = await adminGet(
+      makeRequest('http://localhost/api/auth/admin', { token: USER_TOKEN }),
+    );
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ isAdmin: false });
   });
@@ -66,12 +70,20 @@ describe('POST /api/auth/is-allowed (integration)', () => {
   it('supabase モード: 管理者トークンは allowed=true / 非管理者は false', async () => {
     process.env.NEXT_PUBLIC_AUTH_MODE = 'supabase';
     const admin = await isAllowedPost(
-      makeRequest('http://localhost/api/auth/is-allowed', { method: 'POST', body: {}, token: ADMIN_TOKEN }),
+      makeRequest('http://localhost/api/auth/is-allowed', {
+        method: 'POST',
+        body: {},
+        token: ADMIN_TOKEN,
+      }),
     );
     expect(await admin.json()).toEqual({ allowed: true });
 
     const user = await isAllowedPost(
-      makeRequest('http://localhost/api/auth/is-allowed', { method: 'POST', body: {}, token: USER_TOKEN }),
+      makeRequest('http://localhost/api/auth/is-allowed', {
+        method: 'POST',
+        body: {},
+        token: USER_TOKEN,
+      }),
     );
     expect(await user.json()).toEqual({ allowed: false });
   });

--- a/front/tests/integration/reports-id.test.ts
+++ b/front/tests/integration/reports-id.test.ts
@@ -45,7 +45,10 @@ describe('PATCH /api/reports/[id] (integration)', () => {
 
   it('異常: 未認証 401 / 非管理者 403', async () => {
     const id = await seedReport();
-    const unauth = await PATCH(makeRequest(url(id), { method: 'PATCH', body: { title: 'x' } }), routeContext(id));
+    const unauth = await PATCH(
+      makeRequest(url(id), { method: 'PATCH', body: { title: 'x' } }),
+      routeContext(id),
+    );
     expect(unauth.status).toBe(401);
     const forbidden = await PATCH(
       makeRequest(url(id), { method: 'PATCH', body: { title: 'x' }, token: USER_TOKEN }),
@@ -99,7 +102,9 @@ describe('PATCH /api/reports/[id] (integration)', () => {
   });
 
   it('正常: externalUrls を空配列で全削除', async () => {
-    const id = await seedReport({ externalUrls: [{ url: 'https://a.com' }, { url: 'https://b.com' }] });
+    const id = await seedReport({
+      externalUrls: [{ url: 'https://a.com' }, { url: 'https://b.com' }],
+    });
     const res = await PATCH(
       makeRequest(url(id), { method: 'PATCH', body: { externalUrls: [] }, token: ADMIN_TOKEN }),
       routeContext(id),
@@ -115,9 +120,16 @@ describe('DELETE /api/reports/[id] (integration)', () => {
 
   it('異常: 未認証 401 / 非管理者 403', async () => {
     const id = await seedReport();
-    expect((await DELETE(makeRequest(url(id), { method: 'DELETE' }), routeContext(id))).status).toBe(401);
     expect(
-      (await DELETE(makeRequest(url(id), { method: 'DELETE', token: USER_TOKEN }), routeContext(id))).status,
+      (await DELETE(makeRequest(url(id), { method: 'DELETE' }), routeContext(id))).status,
+    ).toBe(401);
+    expect(
+      (
+        await DELETE(
+          makeRequest(url(id), { method: 'DELETE', token: USER_TOKEN }),
+          routeContext(id),
+        )
+      ).status,
     ).toBe(403);
   });
 

--- a/front/tests/integration/reports.test.ts
+++ b/front/tests/integration/reports.test.ts
@@ -74,7 +74,9 @@ describe('GET /api/reports (integration)', () => {
       externalUrls: { url: string; label: string | null }[];
     }[];
     expect(item.tags).toEqual(['#AI']);
-    expect(item.externalUrls).toEqual([{ id: expect.any(String), url: 'https://example.com', label: 'Note' }]);
+    expect(item.externalUrls).toEqual([
+      { id: expect.any(String), url: 'https://example.com', label: 'Note' },
+    ]);
   });
 });
 


### PR DESCRIPTION
## 変更種別

仕様変更（開発フローの規約変更）

## 概要

CI の `static-analysis` ジョブに `pnpm format:check` を追加し、Prettier の差分ゼロを検証するようにした。併せて未整形だった 39 ファイルを一括整形し、重複していた Prettier 設定を解消した。

## 関連 issue

Closes #186

## 変更理由

**Formatter が導入済み・設定済み・コマンドも存在するのに、CI が検証していなかった。** その結果リポジトリ全体が未整形の状態にあり、`pnpm format` を実行すると無関係な 39 ファイルに差分が出ていた。

`.claude/rules/static-analysis.md` は次のように定めており、現状はこれを満たしていなかった。

> **Linter・Formatter・型チェックはすべて CI で実行し、違反があればマージをブロックする**。ローカル任意実行にしない。
> Formatter は**差分ゼロを検証**する（`--check` / `--test` 系）。

放置すると次の悪循環が固定化する。

1. CI が整形を検証しない → 未整形のコードがマージされる
2. 誰かが `pnpm format` を実行すると無関係なファイルが大量に巻き込まれる
3. その差分をレビューできないため `format` の実行自体が避けられる → 1 へ戻る

Issue #25 の E2E 追加作業（PR #188）中に発見し、#142（コードと `.claude/rules/` の乖離）のサブ issue として分離した。

## 変更前 / 変更後

| 項目 | 変更前 | 変更後 |
|---|---|---|
| CI の静的解析 | `pnpm lint` + `pnpm typecheck` | **`pnpm format:check`** + `pnpm lint` + `pnpm typecheck` |
| 整形状態 | 未整形 39 ファイル | 差分ゼロ |
| Prettier 設定 | `.prettierrc` と `.prettierrc.json` が併存（**後者は読まれない**） | `.prettierrc` のみ |
| `pnpm-lock.yaml` | 整形対象（`pnpm install` のたびに戻る） | `.prettierignore` で対象外 |
| npm scripts | `format` のみ | `format` + `format:check` |
| `git blame` | — | `.git-blame-ignore-revs` で一括整形コミットを除外 |

## 影響範囲

- **影響を受ける機能・API・画面・データ**: なし。整形のみで挙動は一切変えていない
- **後方互換**: あり（アプリケーションの動作に変更なし）
- **開発フローへの影響**: 整形されていないコードは **CI で落ちるようになる**。これは意図した変更

## 移行手順

コード側の移行は不要（後方互換のため）。ただし各開発者のローカルで 1 度だけ以下を推奨する。

```bash
# git blame から一括整形コミットを除外する（GitHub の blame ビューは自動で参照する）
git config blame.ignoreRevsFile .git-blame-ignore-revs
```

設定しない場合、整形対象 39 ファイルの `git blame` がすべて `ef4edeb` を指す。手順は `.git-blame-ignore-revs` の冒頭コメントにも記載した。

エディタの保存時フォーマットを有効にすることも推奨する（`static-analysis.md`「CI で落ちる前に手元で解決する」）。

## 受け入れ基準

- [x] CI で `prettier --check` が実行され、整形差分があればジョブが失敗する
- [x] リポジトリ全体で `pnpm format` を実行しても差分が出ない（`format:check` が green）
- [x] `pnpm-lock.yaml` が整形対象から外れている
- [x] Prettier の設定ファイルが 1 つだけになっている
- [x] 一括整形が単独コミットに分離され、`.git-blame-ignore-revs` に登録されている
- [x] 整形によってアプリケーションの挙動が変わっていない（下記テストで確認）

## テスト

整形のみのため新規テストは追加していない。**既存の全検証を通すことが「挙動を変えていない」ことの根拠**にあたる。

| コマンド | 結果 |
|---|---|
| `pnpm format:check` | pass（差分ゼロ） |
| `pnpm lint` | pass |
| `pnpm typecheck` | pass |
| `pnpm test`（UT） | 168 passed |
| `pnpm test:e2e` | 29 passed |
| `pnpm build` | pass |
| `pnpm test:integration` | 未実行（Docker 必要。CI に委ねた） |

`git blame` が整形コミットではなく元コミットを指すことも手元で確認した。

## ドキュメント

- `.claude/rules/commands.md` — `format:check` を追記。設定ファイルを併置しない理由と、生成物を除外する理由を残した
- `docs/04-non-functional-specification.md` — `static-analysis` ジョブの説明に整形検証を追加
- `docs/11-tasks.md` — タスクを記録

`CLAUDE.md` / `AGENTS.md` のルール一覧は更新不要と判断した。`commands.md` への追記は本文の追加であって、ルールファイルの**追加・削除・改名・説明変更・`globs` 変更**のいずれにも当たらないため（`documentation.md` の影響マップ）。

## コミット構成

論点ごとに分離した。**整形コミットに他の変更を混ぜていない**のは、`.git-blame-ignore-revs` に登録する対象が「整形だけを含むコミット」でなければならないため。

| SHA | 内容 |
|---|---|
| `e38617f` | `format:check` 追加 + CI 組込み + `.prettierrc.json` 削除 + `.prettierignore` 整備 |
| `ef4edeb` | **一括整形のみ**（39 ファイル / +350 -259） |
| `e87a833` | ドキュメント + `.git-blame-ignore-revs` |
| `8c77391` | self-review 指摘の反映（後述） |

レビュー時は `ef4edeb` を飛ばして読むと差分が 8 ファイルに収まる。

## 設計判断（レビューで見てほしい点）

**`.prettierrc.json` の削除**: issue には無かった対応。`.prettierrc` と併存していたが、Prettier は**最初に見つけた 1 つだけ**を読むため後者は死んだ設定だった（`prettier --find-config-path` で確認）。中身は一致していたため挙動は変わらないが、片方だけ編集すると「設定を変えたのに反映されない」形で事故る。

**`.prettierignore` に入れなかったもの**: 当初 `prisma/generated` と `tests/integration/schema.sql` も追加したが、self-review で**どちらも実体を持たない**ことが判明し撤回した（`8c77391`）。前者は `schema.prisma` に `output` 指定がなくディレクトリも存在しない。後者は Prettier に `.sql` のパーサが無く（`--file-info` が `inferredParser: null`）元から対象外だった。「将来 `prettier-plugin-sql` を入れるかもしれない」を理由に残すのは `dead-code.md` が禁じている形のため削除した。

**`.git-blame-ignore-revs` の配置**: リポジトリ直下（`front/` 配下ではない）。GitHub が自動参照するのはリポジトリルートのみのため。